### PR TITLE
MAN-636 fix back link on location not in list page if no locations

### DIFF
--- a/integration_tests/e2e/appointments/location-not-in-list.cy.ts
+++ b/integration_tests/e2e/appointments/location-not-in-list.cy.ts
@@ -1,14 +1,22 @@
 import AppointmentLocationNotInListPage from '../../pages/appointments/location-not-in-list.page'
+import AppointmentLocationPage from '../../pages/appointments/location.page'
+import AppointmentTypePage from '../../pages/appointments/type.page'
 import { completeAttendancePage, completeLocationPage, completeSentencePage, completeTypePage } from './imports'
 
+const loadPage = (locations = true) => {
+  completeTypePage()
+  completeSentencePage()
+  completeAttendancePage()
+  if (locations) {
+    completeLocationPage(4)
+  }
+}
 describe('Arrange an appointment in another location', () => {
   beforeEach(() => {
-    completeTypePage()
-    completeSentencePage()
-    completeAttendancePage()
-    completeLocationPage(4)
+    cy.task('resetMocks')
   })
   it('should render the page', () => {
+    loadPage()
     const locationNotInListPage = new AppointmentLocationNotInListPage()
     locationNotInListPage
       .getElement('p:nth-of-type(1)')
@@ -35,5 +43,19 @@ describe('Arrange an appointment in another location', () => {
     cy.location().should(location => {
       expect(location.href).to.eq('http://localhost:3007/')
     })
+  })
+  it('should return to the locations page when back is clicked', () => {
+    loadPage()
+    cy.get('.govuk-back-link').click()
+    const locationPage = new AppointmentLocationPage()
+    locationPage.checkOnPage()
+  })
+  it('should return to the type page if no locations found and location selection is mandatory', () => {
+    cy.task('stubNoUserLocationsFound')
+    const locations = false
+    loadPage(locations)
+    cy.get('.govuk-back-link').click()
+    const typePage = new AppointmentTypePage()
+    typePage.checkOnPage()
   })
 })

--- a/server/controllers/arrangeAppointment.test.ts
+++ b/server/controllers/arrangeAppointment.test.ts
@@ -319,10 +319,11 @@ describe('controllers/arrangeAppointment', () => {
             isLocationRequired: true,
           },
         },
+        userLocations: [],
       })
       const spy = jest.spyOn(mockRes, 'redirect')
       await controllers.arrangeAppointments.getLocation()(mockReq, mockRes)
-      expect(spy).toHaveBeenCalledWith(`/case/${crn}/arrange-appointment/${uuid}/location-not-in-list`)
+      expect(spy).toHaveBeenCalledWith(`/case/${crn}/arrange-appointment/${uuid}/location-not-in-list?noLocations=true`)
     })
     it('user locations', async () => {
       const mockReq = createMockRequest({
@@ -353,6 +354,20 @@ describe('controllers/arrangeAppointment', () => {
             isLocationRequired: false,
           },
         },
+        userLocations: [
+          {
+            id: 1500066114,
+            code: 'LDN_BCS',
+            description: '1 REGARTH AVENUE',
+            address: {
+              buildingNumber: '1',
+              streetName: 'Regarth Avenue',
+              town: 'Romford',
+              county: 'Essex',
+              postcode: 'RM1 1TP',
+            },
+          },
+        ],
       })
       const spy = jest.spyOn(mockRes, 'render')
       await controllers.arrangeAppointments.getLocation()(mockReq, mockRes)

--- a/server/controllers/arrangeAppointment.ts
+++ b/server/controllers/arrangeAppointment.ts
@@ -31,11 +31,6 @@ const routes = [
   'postArrangeAnotherAppointment',
 ] as const
 
-const renderLocationNotInList: Route<void> = (req, res): void => {
-  const { crn, id } = req.params as Record<string, string>
-  return res.render(`pages/arrange-appointment/location-not-in-list`, { crn, id })
-}
-
 const arrangeAppointmentController: Controller<typeof routes> = {
   redirectToType: () => {
     return async (req, res) => {
@@ -136,13 +131,12 @@ const arrangeAppointmentController: Controller<typeof routes> = {
       const { change } = req.query
       const errors = data?.errors
       const { appointment } = res.locals
-      const { username } = res.locals.user
-      const locations = data.locations[username]
+      const locations = res?.locals?.userLocations || []
       if (errors) {
         delete req.session.data.errors
       }
       if (!locations?.length && appointment.type?.isLocationRequired) {
-        return res.redirect(`/case/${crn}/arrange-appointment/${id}/location-not-in-list`)
+        return res.redirect(`/case/${crn}/arrange-appointment/${id}/location-not-in-list?noLocations=true`)
       }
       return res.render(`pages/arrange-appointment/location`, { crn, id, errors, change })
     }
@@ -163,7 +157,11 @@ const arrangeAppointmentController: Controller<typeof routes> = {
     }
   },
   getLocationNotInList: () => {
-    return async (req, res) => renderLocationNotInList(req, res)
+    return async (req, res) => {
+      const { crn, id } = req.params as Record<string, string>
+      const { noLocations = '' } = req.query
+      return res.render(`pages/arrange-appointment/location-not-in-list`, { crn, id, noLocations })
+    }
   },
   getDateTime: () => {
     return async (req, res) => {

--- a/server/routes/arrangeAppointment.ts
+++ b/server/routes/arrangeAppointment.ts
@@ -78,6 +78,7 @@ const arrangeAppointmentRoutes = async (router: Router, { hmppsAuthClient }: Ser
 
   router.get(
     '/case/:crn/arrange-appointment/:id/location-not-in-list',
+    redirectWizard(['type', 'eventId']),
     getPersonalDetails(hmppsAuthClient),
     controllers.arrangeAppointments.getLocationNotInList(),
   )

--- a/server/views/pages/arrange-appointment/location-not-in-list.njk
+++ b/server/views/pages/arrange-appointment/location-not-in-list.njk
@@ -1,15 +1,19 @@
 {% extends "../_form.njk" %}
 {% set title = 'Arrange an appointment in another location' %}
-{% set backLink = '/case/' + crn + '/arrange-appointment/' + id + '/location' %}
+{% set backLink = ('/case/' + crn + '/arrange-appointment/' + id + '/type') if noLocations else ('/case/' + crn + '/arrange-appointment/' + id + '/location')  %}
 {% set notStandardForm = true %}
 {% block primary %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l" data-qa="pageHeading">{{ title }}</h1>
- <p>You can only arrange appointments from a list of locations associated with the probation practitioner’s team.</p>
-<p>You’ll need to open {{case.name.forename}}’s case on NDelius to arrange an appointment in another location.</p>
-<p><a href="#" target="_blank">Continue on NDelius</a> (opens in new tab)</p>
-<p><a href="/">Cancel and return to preview screen</a></p>
-</div>
-</div>
+      <h1 class="govuk-heading-l" data-qa="pageHeading">{{ title }}</h1>
+      {{noLocations}}
+      <p>You can only arrange appointments from a list of locations associated with the probation practitioner’s team.</p>
+      <p>You’ll need to open {{case.name.forename}}’s case on NDelius to arrange an appointment in another location.</p>
+      <p>
+        <a href="#" target="_blank">Continue on NDelius</a> (opens in new tab)</p>
+      <p>
+        <a href="/">Cancel and return to preview screen</a>
+      </p>
+    </div>
+  </div>
 {% endblock %}


### PR DESCRIPTION
Fixes the back link when the user is redirected to the location not in list page when no user locations are found and a location selection is mandatory for the appointment type.