### PR TITLE
MAN-802 fix eventId bug for person level contact

### DIFF
--- a/server/middleware/getAppointment.ts
+++ b/server/middleware/getAppointment.ts
@@ -118,7 +118,7 @@ export const getAppointment = (hmppsAuthClient: HmppsAuthClient): Route<Promise<
           requirement: sentenceRequirement?.description || null,
           licenceCondition: sentenceLicenceCondition?.mainDescription || null,
           nsi: sentenceNsi?.description || null,
-          forename: parseInt(eventId, 10) === 1 ? forename : null,
+          forename: eventId === 'PERSON_LEVEL_CONTACT' ? forename : null,
         },
         attending: {
           name: selectedUser,

--- a/server/middleware/postAppointments.test.ts
+++ b/server/middleware/postAppointments.test.ts
@@ -7,6 +7,7 @@ import TokenStore from '../data/tokenStore/redisTokenStore'
 import { Sentence } from '../data/model/sentenceDetails'
 import { UserLocation } from '../data/model/caseload'
 import { AppResponse } from '../models/Locals'
+import { AppointmentSession } from '../models/Appointments'
 
 const tokenStore = new TokenStore(null) as jest.Mocked<TokenStore>
 
@@ -76,49 +77,55 @@ const mockSentences = [
   },
 ] as Sentence[]
 
-const req = httpMocks.createRequest({
-  params: {
-    crn,
-    id,
+const mockAppointment: AppointmentSession = {
+  user: {
+    locationCode: 'HMP',
+    teamCode: 'TEA',
+    username,
   },
-  session: {
-    data: {
-      locations: {
-        [username]: mockUserLocations,
-      },
-      sentences: {
-        [crn]: mockSentences,
-      },
-      appointments: {
-        [crn]: {
-          [id]: {
-            user: {
-              locationCode: 'HMP',
-              teamCode: 'TEA',
-              username,
-            },
-            team: 'TEA',
-            type: 'C084',
-            date: '2025-03-12',
-            start: '9:00am',
-            end: '9:30pm',
-            interval: 'WEEK',
-            numberOfAppointments: '2',
-            eventId: 2501138253,
-            requirementId: 1,
-            licenceConditionId: 2500686668,
-            notes: 'Some notes',
-            sensitivity: false,
+  type: 'C084',
+  date: '2025-03-12',
+  start: '9:00am',
+  end: '9:30pm',
+  until: '2025-03-19',
+  interval: 'WEEK',
+  numberOfAppointments: '2',
+  eventId: '250113825',
+  requirementId: '1',
+  licenceConditionId: '2500686668',
+  notes: 'Some notes',
+  sensitivity: 'Yes',
+}
+
+const createMockReq = (appointment: AppointmentSession) => {
+  return httpMocks.createRequest({
+    params: {
+      crn,
+      id,
+    },
+    session: {
+      data: {
+        locations: {
+          [username]: mockUserLocations,
+        },
+        sentences: {
+          [crn]: mockSentences,
+        },
+        appointments: {
+          [crn]: {
+            [id]: appointment,
           },
         },
       },
     },
-  },
-})
+  })
+}
+
+const req = createMockReq(mockAppointment)
 
 const nextSpy = jest.fn()
 
-xdescribe('/middleware/postAppointments', () => {
+describe('/middleware/postAppointments', () => {
   const {
     user: { locationCode, teamCode },
     date,
@@ -131,83 +138,64 @@ xdescribe('/middleware/postAppointments', () => {
     licenceConditionId,
   } = req.session.data.appointments[crn][id]
 
-  const expectedBody = {
-    user: {
-      username,
-      locationCode,
-      teamCode,
-    },
-    type,
-    start: dateTime(date, startTime),
-    end: dateTime(date, endTime),
-    interval,
-    numberOfAppointments: parseInt(repeatCount, 10),
-    createOverlappingAppointment: true,
-    requirementId: 1,
-    licenceConditionId,
-    eventId,
-    uuid: id,
-    until: dateTime(date, endTime),
-    notes: 'Some notes',
-    sensitive: false,
-    visorReport: false,
-  }
-  let spy: jest.SpyInstance
-  beforeEach(async () => {
-    spy = jest.spyOn(MasApiClient.prototype, 'postAppointments').mockImplementation(() => Promise.resolve(''))
+  // let spy: jest.SpyInstance
+
+  const spy = jest.spyOn(MasApiClient.prototype, 'postAppointments').mockImplementation(() => Promise.resolve(''))
+
+  it('should post the correct request body', async () => {
+    const expectedBody = {
+      user: {
+        username,
+        locationCode,
+        teamCode,
+      },
+      type,
+      start: dateTime(date, startTime),
+      end: dateTime(date, endTime),
+      interval,
+      numberOfAppointments: parseInt(repeatCount, 10),
+      createOverlappingAppointment: true,
+      requirementId: 1,
+      licenceConditionId: parseInt(licenceConditionId, 10),
+      eventId: parseInt(eventId, 10),
+      uuid: id,
+      until: dateTime('2025-03-19', endTime),
+      notes: 'Some notes',
+      sensitive: true,
+      visorReport: false,
+    }
     await postAppointments(hmppsAuthClient)(req, res, nextSpy)
-  })
-  it('should post the correct request body', () => {
     expect(spy).toHaveBeenCalledWith(crn, expectedBody)
-  })
-  it('should not call next()', () => {
     expect(nextSpy).not.toHaveBeenCalled()
   })
-})
 
-xdescribe('/middleware/postAppointments', () => {
-  const {
-    user: { locationCode, teamCode },
-    date,
-    start: startTime,
-    end: endTime,
-    type,
-    interval,
-    eventId,
-    numberOfAppointments: repeatCount,
-    licenceConditionId,
-  } = req.session.data.appointments[crn][id]
-
-  const expectedBody = {
-    user: {
-      username,
-      locationCode,
-      teamCode,
-    },
-    type,
-    start: dateTime(date, startTime),
-    end: dateTime(date, endTime),
-    interval,
-    numberOfAppointments: parseInt(repeatCount, 10),
-    createOverlappingAppointment: true,
-    requirementId: 1,
-    licenceConditionId,
-    eventId,
-    uuid: id,
-    until: dateTime(date, endTime),
-    notes: 'Some notes',
-    sensitive: false,
-    visorReport: false,
-  }
-  let spy: jest.SpyInstance
-  beforeEach(async () => {
-    spy = jest.spyOn(MasApiClient.prototype, 'postAppointments').mockImplementation(() => Promise.resolve(''))
-    await postAppointments(hmppsAuthClient)(req, res, nextSpy)
-  })
-  it('should post the correct request body', () => {
+  it('should not include the eventId in the request if PERSON_LEVEL_CONTACT', async () => {
+    const appointment = {
+      ...mockAppointment,
+      eventId: 'PERSON_LEVEL_CONTACT',
+    }
+    const mockReq = createMockReq(appointment)
+    const expectedBody = {
+      user: {
+        username,
+        locationCode,
+        teamCode,
+      },
+      type,
+      start: dateTime(date, startTime),
+      end: dateTime(date, endTime),
+      interval,
+      numberOfAppointments: parseInt(repeatCount, 10),
+      createOverlappingAppointment: true,
+      requirementId: 1,
+      licenceConditionId: parseInt(licenceConditionId, 10),
+      uuid: id,
+      until: dateTime('2025-03-19', endTime),
+      notes: 'Some notes',
+      sensitive: true,
+      visorReport: false,
+    }
+    await postAppointments(hmppsAuthClient)(mockReq, res, nextSpy)
     expect(spy).toHaveBeenCalledWith(crn, expectedBody)
-  })
-  it('should call next()', () => {
-    expect(nextSpy).not.toHaveBeenCalled()
   })
 })

--- a/server/middleware/postAppointments.ts
+++ b/server/middleware/postAppointments.ts
@@ -40,13 +40,15 @@ export const postAppointments = (hmppsAuthClient: HmppsAuthClient): Route<Promis
       end: dateTime(date, end),
       interval,
       numberOfAppointments: parseInt(numberOfAppointments, 10),
-      eventId: parseInt(eventId, 10),
       uuid,
       createOverlappingAppointment: true,
       until: dateTime(untilDate, end),
       notes,
       sensitive: sensitivity === 'Yes',
       visorReport: visorReport === 'Yes',
+    }
+    if (eventId !== 'PERSON_LEVEL_CONTACT') {
+      body.eventId = parseInt(eventId, 10)
     }
     if (requirementId) {
       body.requirementId = parseInt(requirementId as string, 10)

--- a/server/models/Appointments.ts
+++ b/server/models/Appointments.ts
@@ -71,7 +71,7 @@ export interface AppointmentRequestBody {
   end: Date
   interval: AppointmentInterval
   numberOfAppointments: number
-  eventId: number
+  eventId?: number
   uuid: string
   createOverlappingAppointment: true
   requirementId?: number

--- a/server/views/pages/arrange-appointment/sentence.njk
+++ b/server/views/pages/arrange-appointment/sentence.njk
@@ -115,7 +115,7 @@
     {% set allSentences = (allSentences.push(
     {
     text: appointment.meta.forename,
-    value: '1',
+    value: 'PERSON_LEVEL_CONTACT',
     attributes: {
     'data-qa': 'personLevelContact'
     },


### PR DESCRIPTION
Fixes bug where eventId = 1 is included in the request if person level contact.
Changes remove the eventId from the post request.