### PR TITLE
MAN-1050 refactor log outcome links in activity log for mpop appts

### DIFF
--- a/integration_tests/e2e/activityLog.cy.ts
+++ b/integration_tests/e2e/activityLog.cy.ts
@@ -3,6 +3,7 @@ import ActivityLogPage from '../pages/activityLog'
 import ErrorPage from '../pages/error'
 import { activityLogValidation } from '../../server/properties/validation/activityLog'
 import { getErrorMessage } from '../utils/index'
+import RecordAnOutcomePage from '../pages/appointments/record-an-outcome.page'
 
 const keywords = 'Phone call'
 const dateFrom = '11/1/2025'
@@ -408,9 +409,29 @@ context('Activity log', () => {
         'https://ndelius-dummy-url/NDelius-war/delius/JSP/deeplink.xhtml?component=UpdateContact&CRN=X000001&contactID=14',
       )
     page.getCardHeader('timeline7').should('contain.text', 'Office appointment at 10:15am')
+    page.getCardHeader('timeline7').get('.app-summary-card__actions a').should('contain.text', 'Log an outcome')
+
+    page
+      .getCardHeader('timeline7')
+      .find('.app-summary-card__actions a')
+      .should(
+        'have.attr',
+        'href',
+        '/case/X000001/appointments/appointment/16/record-an-outcome?back=/case/X000001/activity-log?page=0',
+      )
+
     page.getCardHeader('timeline8').should('contain.text', 'Initial appointment at 10:15am')
     page.getCardHeader('timeline9').should('contain.text', 'Initial appointment at 10:15am')
     page.getCardHeader('timeline10').should('contain.text', 'Planned Video Contact (NS) at 10:15am')
+  })
+  it('should link to record an outcome page', () => {
+    cy.visit('/case/X000001/activity-log')
+    const page = Page.verifyOnPage(ActivityLogPage)
+    page.getCardHeader('timeline7').find('.app-summary-card__actions a').click()
+    const recordAnOutcomePage = new RecordAnOutcomePage()
+    cy.get('#outcomeRecorded').click()
+    recordAnOutcomePage.getSubmitBtn().click()
+    page.checkOnPage()
   })
   it('should display the pagination navigation', () => {
     cy.visit('/case/X000001/activity-log')

--- a/integration_tests/e2e/activityLogDetails.cy.ts
+++ b/integration_tests/e2e/activityLogDetails.cy.ts
@@ -1,4 +1,5 @@
 import ActivityLogDetailsPage from '../pages/activityLogDetails'
+import RecordAnOutcomePage from '../pages/appointments/record-an-outcome.page'
 
 context('Activity log details', () => {
   afterEach(() => {
@@ -65,7 +66,8 @@ context('Activity log details', () => {
     page.assertAnchorElementAtIndexWithin(cardBody, 1, 1, '/case/X000001/activity-log/activity/15/note/0')
     page.assertAnchorElementAtIndexWithin(cardBody, 1, 2, '/case/X000001/activity-log/activity/15/note/2')
   })
-  it('should render an appointment without an outcome', () => {
+  it('should render a MPOP managed appointment without an outcome', () => {
+    let activityLogPage: ActivityLogDetailsPage
     cy.visit('/case/X000001/activity-log/activity/16')
     const page = new ActivityLogDetailsPage()
     page.setPageTitle('Office appointment with Terry Jones')
@@ -77,7 +79,7 @@ context('Activity log details', () => {
       .should(
         'have.attr',
         'href',
-        'https://ndelius-dummy-url/NDelius-war/delius/JSP/deeplink.xhtml?component=UpdateContact&CRN=X000001&contactID=16',
+        '/case/X000001/appointments/appointment/16/record-an-outcome?back=/case/X000001/activity-log/activity/16',
       )
     page.getCardHeader('appointmentDetails').should('contain.text', 'Appointment details')
     page
@@ -101,6 +103,24 @@ context('Activity log details', () => {
     page.getCardElement('appointmentDetails', '.govuk-summary-list__key', 5).should('contain.text', 'Sensitive')
     page.getCardElement('appointmentDetails', '.govuk-summary-list__value', 5).should('contain.text', 'No')
     page.getCardHeader('outcomeDetails').should('not.exist')
+    cy.get('.note-panel').find('a').click()
+    const logOutcomePage = new RecordAnOutcomePage()
+    logOutcomePage.checkOnPage()
+    cy.get('#outcomeRecorded').click()
+    logOutcomePage.getSubmitBtn().click()
+    page.checkOnPage()
+  })
+  it('should render an NDelius managed appointment without an outcome', () => {
+    cy.visit('/case/X000001/activity-log/activity/14')
+    cy.get('.note-panel').find('.govuk-warning-text__text').should('contain.text', 'Outcome not recorded')
+    cy.get('.note-panel')
+      .find('a')
+      .should('contain.text', 'Log an outcome on NDelius (opens in new tab)')
+      .should(
+        'have.attr',
+        'href',
+        'https://ndelius-dummy-url/NDelius-war/delius/JSP/deeplink.xhtml?component=UpdateContact&CRN=X000001&contactID=14',
+      )
   })
   it('should render a complied appointment with a single selected note', () => {
     cy.visit('/case/X000001/activity-log/activity/15/note/0')

--- a/server/controllers/appointments.test.ts
+++ b/server/controllers/appointments.test.ts
@@ -331,6 +331,30 @@ describe('controllers/appointments', () => {
         expect(redirectSpy).toHaveBeenCalledWith(`/case/${crn}/appointments/appointment/${id}/manage`)
       })
     })
+    describe('If back query param in url', () => {
+      const mockedReq = httpMocks.createRequest({
+        params: {
+          crn,
+          id,
+          contactId,
+          actionType,
+        },
+        query: {
+          back: '/back/url',
+        },
+        body: {
+          outcomeRecorded: 'yes',
+        },
+      })
+      beforeEach(async () => {
+        mockIsValidCrn.mockReturnValue(true)
+        mockIsNumericString.mockReturnValue(true)
+        await controllers.appointments.postRecordAnOutcome(hmppsAuthClient)(mockedReq, res)
+      })
+      it('should post the request then redirect to the back link', () => {
+        expect(redirectSpy).toHaveBeenCalledWith(mockedReq.query.back)
+      })
+    })
   })
   describe('get add note', () => {
     const uploadedFiles = [{ filename: 'mock-file.pdf' }] as Express.Multer.File[]

--- a/server/controllers/appointments.ts
+++ b/server/controllers/appointments.ts
@@ -205,8 +205,9 @@ const appointmentsController: Controller<typeof routes, void> = {
         id: parseInt(id, 10),
         outcomeRecorded: true,
       }
+      const { back } = req.query as Record<string, string>
       await masClient.patchAppointment(body)
-      return res.redirect(`/case/${crn}/appointments/appointment/${id}/manage`)
+      return res.redirect(back ?? `/case/${crn}/appointments/appointment/${id}/manage`)
     }
   },
   getAddNote: _hmppsAuthClient => {

--- a/server/views/pages/activity-log/_appointment-timeline-entry.njk
+++ b/server/views/pages/activity-log/_appointment-timeline-entry.njk
@@ -1,23 +1,24 @@
 {% set hasAppointmentStartTimePassed = isInThePast(entry.startDateTime) %}
-{% set shouldPromptToRecordAnOutcome = entry.hasOutcome === false and hasAppointmentStartTimePassed  %}
+{% set shouldPromptToRecordAnOutcome = entry.hasOutcome === false and hasAppointmentStartTimePassed %}
 {% set appointment = entry %}
 
 {% set titleHtml %}
-  <span class="govuk-heading-s govuk-!-margin-bottom-0">
-    <a href="/case/{{ crn }}/activity-log/activity/{{ entry.id }}?category={{ category }}&view=default&requirement={{ requirement }}&{{filters.queryStr}}&page={{page}}">{{ entry.type }} at {{ entry.startDateTime | govukTime }}<span class="govuk-visually-hidden"> on {{ thisDate }}</span></a>
-  </span>
+<span class="govuk-heading-s govuk-!-margin-bottom-0">
+  <a href="/case/{{ crn }}/activity-log/activity/{{ entry.id }}?category={{ category }}&view=default&requirement={{ requirement }}&{{filters.queryStr}}&page={{page}}">{{ entry.type }} at {{ entry.startDateTime | govukTime }}
+    <span class="govuk-visually-hidden"> on {{ thisDate }}</span></a>
+</span>
 {% endset %}
 
 {% set html %}
-  {% include './_timeline-notes.njk' %}
+{% include './_timeline-notes.njk' %}
 {% endset %}
 
 {% set actionsHtml %}
-  {% if shouldPromptToRecordAnOutcome %}
-    <a href="{{ deliusDeepLinkUrl('UpdateContact', crn, entry.id) }}" target="_blank" rel="external noopener noreferrer" class="govuk-!-margin-left-2 govuk-!-font-weight-bold">Log an outcome<span class="govuk-visually-hidden"> (opens in new tab)</span></a>
-  {% else %}
-    {{ appComplianceTag({ entry: entry, classes: 'govuk-!-margin-left-2' }) }}
-  {% endif %}
+{% if shouldPromptToRecordAnOutcome %}
+  {% include './_log-outcome-link.njk' %}
+{% else %}
+  {{ appComplianceTag({ entry: entry, classes: 'govuk-!-margin-left-2' }) }}
+{% endif %}
 {% endset %}
 
 {{ appSummaryCard({

--- a/server/views/pages/activity-log/_communication-timeline-entry.njk
+++ b/server/views/pages/activity-log/_communication-timeline-entry.njk
@@ -1,19 +1,20 @@
 {% set hasAppointmentStartTimePassed = isInThePast(entry.startDateTime) %}
-{% set shouldPromptToRecordAnOutcome = entry.hasOutcome === false and hasAppointmentStartTimePassed  %}
+{% set shouldPromptToRecordAnOutcome = entry.hasOutcome === false and hasAppointmentStartTimePassed %}
 
 {% set titleHtml %}
-  <a href="/case/{{ crn }}/activity-log/activity/{{ entry.id }}?category={{ category }}&view=default&requirement={{ requirement }}&{{filters.queryStr}}&page={{page}}" class="govuk-!-font-weight-bold">{% include './_communication-title.njk' %} at&nbsp;{{ entry.startDateTime | govukTime }}<span class="govuk-visually-hidden"> on {{ thisDate }}</span></a>
+<a href="/case/{{ crn }}/activity-log/activity/{{ entry.id }}?category={{ category }}&view=default&requirement={{ requirement }}&{{filters.queryStr}}&page={{page}}" class="govuk-!-font-weight-bold">{% include './_communication-title.njk' %} at&nbsp;{{ entry.startDateTime | govukTime }}
+  <span class="govuk-visually-hidden"> on {{ thisDate }}</span></a>
 {% endset %}
 {% set actionsHtml %}
-  {% if shouldPromptToRecordAnOutcome %}
-    <a href="{{ deliusDeepLinkUrl('UpdateContact', crn, entry.id) }}" target="_blank" rel="external noopener noreferrer" class="govuk-!-margin-left-2 govuk-!-font-weight-bold">Log an outcome<span class="govuk-visually-hidden"> (opens in new tab)</span></a>
-  {% else %}
-    {{ appComplianceTag({ entry: entry, classes: 'govuk-!-margin-left-2' }) }}
-  {% endif %}
+{% if shouldPromptToRecordAnOutcome %}
+  {% include './_log-outcome-link.njk' %}
+{% else %}
+  {{ appComplianceTag({ entry: entry, classes: 'govuk-!-margin-left-2' }) }}
+{% endif %}
 {% endset %}
 
 {% set html %}
-  {% include './_timeline-notes.njk' %}
+{% include './_timeline-notes.njk' %}
 {% endset %}
 
 {{ appSummaryCard({

--- a/server/views/pages/activity-log/_compact-timeline-entry.njk
+++ b/server/views/pages/activity-log/_compact-timeline-entry.njk
@@ -1,34 +1,34 @@
 {% set hasOutcomeBeenConfirmed = entry.didTheyComply === true or entry.rescheduled === true %}
 {% set hasAppointmentStartTimePassed = isInThePast(entry.startDateTime) %}
-{% set shouldPromptToRecordAnOutcome = entry.hasOutcome === false and hasAppointmentStartTimePassed  %}
+{% set shouldPromptToRecordAnOutcome = entry.hasOutcome === false and hasAppointmentStartTimePassed %}
 
 {% set titleHtml %}
-  <p class="govuk-body govuk-!-margin-bottom-1" data-qa="timeline{{ loop.index }}Card">
-    <a href="/case/{{ crn }}/activity-log/activity/{{ entry.id }}?category={{ category }}&view=compact&requirement={{ requirement }}&{{filters.queryStr}}&page={{page}}">
-      {% if entry.isAppointment === true %}
-        {{ appComplianceTag({ entry: entry, classes: 'govuk-!-margin-left-2', compact: true }) }}
-        {{ entry.type }} at&nbsp;{{ entry.startDateTime | govukTime }}
-      {% elseif entry.isCommunication %}
-        {{ appComplianceTag({ entry: entry, classes: 'govuk-!-margin-left-2', compact: true }) }}
-        {% include './_communication-title.njk' %} at {{ entry.startDateTime | govukTime }}
-      {% else %}
-        {{ appComplianceTag({ entry: entry, classes: 'govuk-!-margin-left-2', compact: true }) }}
-        {{ entry.type }}
-      {% endif %}
-      <span class="govuk-visually-hidden"> on {{ thisDate }}
+<p class="govuk-body govuk-!-margin-bottom-1" data-qa="timeline{{ loop.index }}Card">
+  <a href="/case/{{ crn }}/activity-log/activity/{{ entry.id }}?category={{ category }}&view=compact&requirement={{ requirement }}&{{filters.queryStr}}&page={{page}}">
+    {% if entry.isAppointment === true %}
+      {{ appComplianceTag({ entry: entry, classes: 'govuk-!-margin-left-2', compact: true }) }}
+      {{ entry.type }} at&nbsp;{{ entry.startDateTime | govukTime }}
+    {% elseif entry.isCommunication %}
+      {{ appComplianceTag({ entry: entry, classes: 'govuk-!-margin-left-2', compact: true }) }}
+      {% include './_communication-title.njk' %} at {{ entry.startDateTime | govukTime }}
+    {% else %}
+      {{ appComplianceTag({ entry: entry, classes: 'govuk-!-margin-left-2', compact: true }) }}
+      {{ entry.type }}
+    {% endif %}
+    <span class="govuk-visually-hidden"> on {{ thisDate }}
     </a>
-     {% if shouldPromptToRecordAnOutcome %}
-        <br /><a href="{{ deliusDeepLinkUrl('UpdateContact', crn, entry.id) }}" target="_blank" rel="external noopener noreferrer" class="govuk-!-font-weight-bold">Log an outcome<span class="govuk-visually-hidden"> (opens in new tab)</span></a>
-     {% endif %}
+    {% if shouldPromptToRecordAnOutcome %}
+      <br/>{% include './_log-outcome-link.njk' %}
+    {% endif %}
   </p>
-{% endset %}
+  {% endset %}
 
-{% set html %}
+  {% set html %}
   {% include './_timeline-notes.njk' %}
-{% endset %}
+  {% endset %}
 
-{% set actionsHtml %}
-    {{ appComplianceTag({ entry: entry, classes: 'govuk-!-margin-left-2' }) }}
-{% endset %}
+  {% set actionsHtml %}
+  {{ appComplianceTag({ entry: entry, classes: 'govuk-!-margin-left-2' }) }}
+  {% endset %}
 
-{{ titleHtml | safe }}
+  {{ titleHtml | safe }}

--- a/server/views/pages/activity-log/_log-outcome-link.njk
+++ b/server/views/pages/activity-log/_log-outcome-link.njk
@@ -1,0 +1,5 @@
+{% if entry.deliusManaged %}
+    <a href="{{ deliusDeepLinkUrl('UpdateContact', crn, entry.id) }}" target="_blank" rel="external noopener noreferrer" class="govuk-!-margin-left-2 govuk-!-font-weight-bold">Log an outcome<span class="govuk-visually-hidden"> (opens in new tab)</span></a>
+{% else %}
+    <a href="/case/{{ crn }}/appointments/appointment/{{ entry.id }}/record-an-outcome?back=/case/{{ crn }}/activity-log{{ '?page=' + page if page else '' }}" class="govuk-!-margin-left-2 govuk-!-font-weight-bold">Log an outcome</a>
+{% endif %}

--- a/server/views/pages/activity-log/_other-timeline-entry.njk
+++ b/server/views/pages/activity-log/_other-timeline-entry.njk
@@ -1,27 +1,28 @@
 {% set hasAppointmentStartTimePassed = isInThePast(entry.startDateTime) %}
-{% set shouldPromptToRecordAnOutcome = entry.hasOutcome === false and hasAppointmentStartTimePassed  %}
+{% set shouldPromptToRecordAnOutcome = entry.hasOutcome === false and hasAppointmentStartTimePassed %}
 
 {% set titleHtml %}
-  <a href="/case/{{ crn }}/activity-log/activity/{{ entry.id }}?category={{ category }}&view=default&requirement={{ requirement }}&{{filters.queryStr}}&page={{page}}" class="govuk-!-font-weight-bold">
-    {{ entry.type }}<span class="govuk-visually-hidden"> on {{ thisDate }}</span>
-  </a>
+<a href="/case/{{ crn }}/activity-log/activity/{{ entry.id }}?category={{ category }}&view=default&requirement={{ requirement }}&{{filters.queryStr}}&page={{page}}" class="govuk-!-font-weight-bold">
+  {{ entry.type }}
+  <span class="govuk-visually-hidden"> on {{ thisDate }}</span>
+</a>
 {% endset %}
 
 {% set actionsHtml %}
-  {% if entry.countsTowardsRAR %}
-    {{ govukTag({text: 'RAR', classes: 'govuk-tag--purple'}) }}
-  {% endif %}
+{% if entry.countsTowardsRAR %}
+  {{ govukTag({text: 'RAR', classes: 'govuk-tag--purple'}) }}
+{% endif %}
 
-  {% if shouldPromptToRecordAnOutcome %}
-     <a href="{{ deliusDeepLinkUrl('UpdateContact', crn, entry.id) }}"target="_blank" rel="external noopener noreferrer" class="govuk-!-font-weight-bold govuk-!-margin-left-2">Log an outcome<span class="govuk-visually-hidden"> (opens in new tab)</span></a>
-  {% else %}
-     {{ appComplianceTag({ entry: entry, classes: 'govuk-!-margin-left-2' }) }}
-  {% endif %}
+{% if shouldPromptToRecordAnOutcome %}
+  {% include './_log-outcome-link.njk' %}
+{% else %}
+  {{ appComplianceTag({ entry: entry, classes: 'govuk-!-margin-left-2' }) }}
+{% endif %}
 
 {% endset %}
 
 {% set html %}
-  {% include './_timeline-notes.njk' %}
+{% include './_timeline-notes.njk' %}
 {% endset %}
 
 {{ appSummaryCard({

--- a/server/views/pages/activity-log/_system-contact-timeline-entry.njk
+++ b/server/views/pages/activity-log/_system-contact-timeline-entry.njk
@@ -1,22 +1,23 @@
 {% set hasAppointmentStartTimePassed = isInThePast(entry.startDateTime) %}
-{% set shouldPromptToRecordAnOutcome = entry.hasOutcome === false and hasAppointmentStartTimePassed  %}
+{% set shouldPromptToRecordAnOutcome = entry.hasOutcome === false and hasAppointmentStartTimePassed %}
 
 {% set titleHtml %}
- <span class="govuk-heading-s govuk-!-margin-bottom-0">
- <a href="/case/{{ crn }}/activity-log/activity/{{ entry.id }}?category={{ category }}&view=default&requirement={{ requirement }}&{{filters.queryStr}}&page={{page}}" class="app-!-inherit-colour">{{ entry.type }}<span class="govuk-visually-hidden"> on {{ thisDate }}</span></a>
- </span>
+<span class="govuk-heading-s govuk-!-margin-bottom-0">
+  <a href="/case/{{ crn }}/activity-log/activity/{{ entry.id }}?category={{ category }}&view=default&requirement={{ requirement }}&{{filters.queryStr}}&page={{page}}" class="app-!-inherit-colour">{{ entry.type }}
+    <span class="govuk-visually-hidden"> on {{ thisDate }}</span></a>
+</span>
 {% endset %}
 
 {% set actionsHtml %}
-  {% if shouldPromptToRecordAnOutcome %}
-    <a href="{{ deliusDeepLinkUrl('UpdateContact', crn, entry.id) }}"target="_blank" rel="external noopener noreferrer" class="govuk-!-margin-left-2 govuk-!-font-weight-bold">Log an outcome<span class="govuk-visually-hidden"> (opens in new tab)</span></a>
-  {% else %}
-    {{ appComplianceTag({ entry: entry, classes: 'govuk-!-margin-left-2' }) }}
-  {% endif %}
+{% if shouldPromptToRecordAnOutcome %}
+  {% include './_log-outcome-link.njk' %}
+{% else %}
+  {{ appComplianceTag({ entry: entry, classes: 'govuk-!-margin-left-2' }) }}
+{% endif %}
 {% endset %}
 
 {% set html %}
-  {% include './_timeline-notes.njk' %}
+{% include './_timeline-notes.njk' %}
 {% endset %}
 
 {{ appSummaryCard({

--- a/server/views/pages/appointments/appointment.njk
+++ b/server/views/pages/appointments/appointment.njk
@@ -7,6 +7,11 @@
   '' %}
 {% set hasAppointmentStartTimePassed = isInThePast(appointment.startDateTime) %}
 {% set shouldPromptToRecordAnOutcome = appointment.hasOutcome === false and hasAppointmentStartTimePassed %}
+{% set logOutcomeLinkHtml = '<a href="/case/' + crn + '/appointments/appointment/' + appointment.id + '/record-an-outcome?back=/case/' + crn + '/activity-log/activity/' + appointment.id + '">Log an outcome</a>' %}
+{% if appointment.deliusManaged %}
+  {% set logOutcomeLinkHtml = '<a href="' + deliusDeepLinkUrl('UpdateContact', crn, appointment.id) + '" target="_blank" rel="external noopener noreferrer">Log an outcome on NDelius (opens in new tab)</a>' %}
+{% endif %}
+
 {% block beforeContent %}
   {{ govukBreadcrumbs({
   items: [
@@ -60,7 +65,7 @@
       <div class="govuk-grid-column-two-thirds">
         <div class="note-panel govuk-!-margin-bottom-6">
           {{ govukWarningText({
-          html: 'Outcome not recorded<br /><a href="' + deliusDeepLinkUrl('UpdateContact', crn, appointment.id) + '" target="_blank" rel="external noopener noreferrer">Log an outcome on NDelius (opens in new tab)</a>',
+          html: 'Outcome not recorded<br />' + logOutcomeLinkHtml,
           iconFallbackText: 'Warning',
           classes: 'govuk-!-margin-bottom-0'
         }) }}

--- a/wiremock/mappings/X000001-activity-log.json
+++ b/wiremock/mappings/X000001-activity-log.json
@@ -177,6 +177,7 @@
               "startDateTime": "2024-03-22T10:15:00.382936Z",
               "endDateTime": "2024-03-22T10:30:00.382936Z",
               "rarToolKit": "Choices and Changes",
+              "deliusManaged": false,
               "isSensitive": false,
               "hasOutcome": true,
               "outcome": "User-generated free text content",
@@ -210,6 +211,7 @@
               "isSensitive": false,
               "hasOutcome": false,
               "wasAbsent": true,
+              "deliusManaged": true,
               "appointmentNotes": [
                 {
                   "id": 0,
@@ -1173,6 +1175,7 @@
             "isSensitive": false,
             "hasOutcome": false,
             "wasAbsent": true,
+            "deliusManaged": true,
             "appointmentNotes": [
               {
                 "id": 0,
@@ -1350,6 +1353,7 @@
             "hasOutcome": false,
             "wasAbsent": true,
             "isInPast": true,
+            "deliusManaged": false,
             "nonComplianceReason": "Was very argumentative and left the appointment",
             "didTheyComply": false,
             "isAppointment": true,


### PR DESCRIPTION
1. Refactors the 'Log an outcome' links on the activity log page, to either link to Delius or record an outcome page within MPOP.
2. Adds back link into url so once a outcome is recorded the user is redirected back to activity log