### PR TITLE
MAN-1113 fix double click to submit date/time page

### DIFF
--- a/wiremock/mappings/X778160-appointment-check.json
+++ b/wiremock/mappings/X778160-appointment-check.json
@@ -2,7 +2,7 @@
   "mappings": [
     {
       "request": {
-        "urlPattern": "/mas/appointment/X778160/check",
+        "urlPattern": "/mas/appointment/.*/check",
         "method": "POST"
       },
       "response": {


### PR DESCRIPTION
Update wiremock to contain wildcard crn to fix double click to submit date/time page