### PR TITLE
MAN-1195 dont post patch request on attended complied page

### DIFF
--- a/server/controllers/appointments.test.ts
+++ b/server/controllers/appointments.test.ts
@@ -85,7 +85,6 @@ const req = httpMocks.createRequest({
     actionType,
   },
   url: '',
-  session: {},
   query: { page: '', view: 'default', category: 'mock-category', contactId },
   session: {
     data: {},
@@ -392,34 +391,6 @@ describe('controllers/appointments', () => {
       })
       it('should redirect to the add notes page', () => {
         expect(redirectSpy).toHaveBeenCalledWith(`/case/${crn}/appointments/appointment/${id}/add-note`)
-      })
-    })
-
-    describe('If back query param in url', () => {
-      const mockedReq = httpMocks.createRequest({
-        params: {
-          crn,
-          id,
-          contactId,
-          actionType,
-        },
-        query: {
-          back: '/back/url',
-        },
-        body: {
-          outcomeRecorded: 'yes',
-        },
-        session: {
-          data: {},
-        },
-      })
-      beforeEach(async () => {
-        mockIsValidCrn.mockReturnValue(true)
-        mockIsNumericString.mockReturnValue(true)
-        await controllers.appointments.postAttendedComplied(hmppsAuthClient)(mockedReq, res)
-      })
-      it('should redirect to the back link', () => {
-        expect(redirectSpy).toHaveBeenCalledWith(mockedReq.query.back)
       })
     })
   })

--- a/server/controllers/appointments.ts
+++ b/server/controllers/appointments.ts
@@ -246,8 +246,7 @@ const appointmentsController: Controller<typeof routes, void> = {
       }
       const { data } = req.session
       setDataValue(data, ['appointments', crn, id, 'outcomeRecorded'], true)
-      const { back } = req.query as Record<string, string>
-      return res.redirect(back ?? `/case/${crn}/appointments/appointment/${id}/add-note`)
+      return res.redirect(`/case/${crn}/appointments/appointment/${id}/add-note`)
     }
   },
   getAddNote: _hmppsAuthClient => {

--- a/server/models/Appointments.ts
+++ b/server/models/Appointments.ts
@@ -37,6 +37,7 @@ export interface AppointmentSession {
   repeatingDates?: string[]
   notes?: string
   sensitivity?: YesNo
+  outcomeRecorded?: boolean
 }
 
 export interface AppointmentType {


### PR DESCRIPTION
Removes the appointment patch request when posting the attended and complied page.
Saves outcome recorded session when attended and complied page is posted.
Patches outcome recorded when posting add note page if session exists.