### PR TITLE
MAN-2361 fix to display pop forename in sms

### DIFF
--- a/server/middleware/postAppointments.test.ts
+++ b/server/middleware/postAppointments.test.ts
@@ -220,7 +220,7 @@ const mockAppointmentsPostResponse: AppointmentsPostResponse = {
 const checkOutlookEventRequest = (smsRequest = false) => {
   const { date, start } = mockAppointment
   const smsEventRequest: SmsEventRequest = {
-    firstName: mockUser.firstName,
+    firstName: mockCase.name.forename,
     mobileNumber: res.locals.case.mobileNumber,
     crn,
     smsOptIn: true,

--- a/server/middleware/postAppointments.ts
+++ b/server/middleware/postAppointments.ts
@@ -109,9 +109,9 @@ export const postAppointments = (hmppsAuthClient: HmppsAuthClient): Route<Promis
           appointmentLocation = null,
           appointmentTypeCode = null,
         } = getDataValue<SmsPreviewRequest>(data, ['appointments', crn, uuid, 'smsPreview', 'request'])
-
+        const popFirstName = res.locals.case.name.forename
         outlookEventRequestBody.smsEventRequest = {
-          firstName,
+          firstName: popFirstName,
           mobileNumber,
           crn,
           smsOptIn: true,


### PR DESCRIPTION
Fixes bug in SMS request to use POP first name rather than logged in user first name