### PR TITLE
Update policy_scan.yml (slack_failure_results) to use shared actions

### DIFF
--- a/.github/workflows/policy_scan.yml
+++ b/.github/workflows/policy_scan.yml
@@ -147,7 +147,7 @@ jobs:
           path: output.txt
       - name: send a failure slack message
         if: failure()  && inputs.channel_id != 'NO_SLACK'
-        uses: ministryofjustice/hmpps-github-actions/.github/actions/slack_failure_results@v2 # WORKFLOW_VERSION
+        uses: ministryofjustice/hmpps-github-shared-actions/.github/actions/slack_failure_results@7277152a31c152f8d65ccdea0df7cceca7ab3856 # v1
         with:
           SLACK_BOT_TOKEN: ${{ secrets.HMPPS_SRE_SLACK_BOT_TOKEN }}
           channel_id: ${{ inputs.channel_id }}


### PR DESCRIPTION
This will reduce the maintenance burden - we won't need to have two action codebases
(new shared actions created to disconnect workflows from actions)