### PR TITLE
ESUP-1608 - Add mandatory SPO approval confirmation to eligibility page for online check-ins

### DIFF
--- a/integration_tests/e2e/appointments/check-ins.cy.ts
+++ b/integration_tests/e2e/appointments/check-ins.cy.ts
@@ -34,6 +34,7 @@ import PreviewFeelingPage from '../../pages/check-ins/questions/preview/feeling'
 import PreviewSupportPage from '../../pages/check-ins/questions/preview/support'
 import EditQuestionPage from '../../pages/check-ins/questions/edit-question'
 import ListQuestionsPage from '../../pages/check-ins/questions/list-questions'
+import EligibilitySPOApprovalPage from '../../pages/check-ins/eligibility-spo-approval'
 
 const loadPage = () => {
   cy.task('resetMocks')
@@ -108,13 +109,8 @@ context('Appointment check-ins', () => {
     checkPage.getSubmitBtn().click()
 
     const fullPage = new EligibilityFullPage()
-    fullPage.getReplacementRadio().check()
-    fullPage.getSubmitBtn().click()
-
-    const dateFrequencyPage = new DateFrequencyPage()
-    dateFrequencyPage.checkOnPage()
   })
-  it('should navigate to date frequency when "To replace some face-to-face contact" radio is selected', () => {
+  it('should navigate to SPO approval when "To replace some face-to-face contact" radio is selected', () => {
     loadPage()
     cy.get('[data-qa="online-checkin-btn"]').click()
 
@@ -126,8 +122,26 @@ context('Appointment check-ins', () => {
     fullPage.getReplacementRadio().check()
     fullPage.getSubmitBtn().click()
 
-    const dateFrequencyPage = new DateFrequencyPage()
-    dateFrequencyPage.checkOnPage()
+    const spoApprovalPage = new EligibilitySPOApprovalPage()
+    spoApprovalPage.checkOnPage()
+  })
+
+  it('should navigate to date frequency when SPO approval checkbox is checked', () => {
+    loadPage()
+    cy.get('[data-qa="online-checkin-btn"]').click()
+
+    const checkPage = new EligibilityCheckPage()
+    checkPage.getNoneOption().check()
+    checkPage.getSubmitBtn().click()
+
+    const fullPage = new EligibilityFullPage()
+    fullPage.getReplacementRadio().check()
+    fullPage.getSubmitBtn().click()
+
+    const spoApprovalPage = new EligibilitySPOApprovalPage()
+    spoApprovalPage.checkOnPage()
+    spoApprovalPage.getCheckbox()
+    spoApprovalPage.getSubmitBtn()
   })
 
   it('should navigate to date frequency when "As well as existing face-to-face contact" radio is selected', () => {

--- a/integration_tests/pages/check-ins/eligibility-spo-approval.ts
+++ b/integration_tests/pages/check-ins/eligibility-spo-approval.ts
@@ -1,0 +1,11 @@
+import Page, { PageElement } from '../page'
+
+export default class EligibilitySPOApprovalPage extends Page {
+  constructor() {
+    super("Check you've got approval before you sign")
+  }
+
+  getSubmitBtn = (): PageElement => cy.get('[data-qa="submit-btn"]')
+
+  getCheckbox = (): PageElement => cy.get('input[value="spo-approval"]')
+}

--- a/server/controllers/check-ins.test.ts
+++ b/server/controllers/check-ins.test.ts
@@ -264,6 +264,71 @@ describe('checkInsController', () => {
       })
     })
 
+    describe('getSPOApprovalPage', () => {
+      it('renders spo approval page when CRN and id are valid', async () => {
+        mockIsValidCrn.mockReturnValue(true)
+        mockIsValidUUID.mockReturnValue(true)
+
+        const req = baseReq()
+        const { id } = req.params as Record<string, string>
+        await controllers.checkIns.getSPOApprovalPage(hmppsAuthClient)(req, res)
+
+        expect(renderSpy).toHaveBeenCalledWith('pages/check-in/spo-approval.njk', {
+          crn,
+          id,
+          back: req.query.back,
+          isApproved: false,
+        })
+        expect(mockRenderError).not.toHaveBeenCalled()
+        checkSendAuditMessage(res, 'VIEW_MAS_SPO_APPROVAL_TO_USE_CHECK_INS', crn, SubjectType.CRN)
+      })
+
+      it('returns 404 when CRN is invalid', async () => {
+        mockIsValidCrn.mockReturnValue(false)
+        mockIsValidUUID.mockReturnValue(true)
+
+        const req = baseReq()
+        await controllers.checkIns.getSPOApprovalPage(hmppsAuthClient)(req, res)
+
+        expect(mockRenderError).toHaveBeenCalledWith(404)
+        expect(mockMiddlewareFn).toHaveBeenCalledWith(req, res)
+      })
+    })
+
+    describe('postSPOApprovalPage', () => {
+      it('redirects to date frequency when CRN and id are valid', async () => {
+        mockIsValidCrn.mockReturnValue(true)
+        mockIsValidUUID.mockReturnValue(true)
+
+        const req = baseReq()
+        await controllers.checkIns.postSPOApprovalPage(hmppsAuthClient)(req, res)
+
+        expect(redirectSpy).toHaveBeenCalledWith(`/case/${crn}/appointments/${uuid}/check-in/date-frequency`)
+      })
+
+      it('returns 404 when CRN is invalid', async () => {
+        mockIsValidCrn.mockReturnValue(false)
+        mockIsValidUUID.mockReturnValue(true)
+
+        const req = baseReq()
+        await controllers.checkIns.postSPOApprovalPage(hmppsAuthClient)(req, res)
+
+        expect(mockRenderError).toHaveBeenCalledWith(404)
+        expect(mockMiddlewareFn).toHaveBeenCalledWith(req, res)
+      })
+
+      it('returns 404 when id is not a valid UUID', async () => {
+        mockIsValidCrn.mockReturnValue(true)
+        mockIsValidUUID.mockReturnValue(false)
+
+        const req = baseReq()
+        await controllers.checkIns.postSPOApprovalPage(hmppsAuthClient)(req, res)
+
+        expect(mockRenderError).toHaveBeenCalledWith(404)
+        expect(mockMiddlewareFn).toHaveBeenCalledWith(req, res)
+      })
+    })
+
     describe('getSupplementaryEligibilityPage', () => {
       it('Renders supplementary eligibility page when CRN and id are valid', async () => {
         mockIsValidCrn.mockReturnValue(true)

--- a/server/controllers/check-ins.ts
+++ b/server/controllers/check-ins.ts
@@ -50,6 +50,8 @@ const routes = [
   'postFullEligibilityPage',
   'getSupplementaryEligibilityPage',
   'postSupplementaryEligibilityPage',
+  'getSPOApprovalPage',
+  'postSPOApprovalPage',
   'getDateFrequencyPage',
   'postDateFrequencyPage',
   'getContactPreferencePage',
@@ -220,6 +222,12 @@ const checkInsController: Controller<typeof routes, void> = {
         return renderError(404)(req, res)
       }
       setDataValue(data, ['esupervision', crn, id, 'checkins', 'id'], id)
+      const eligibilityChoice: string | any[] =
+        req.session.data?.esupervision?.[crn]?.[id]?.checkins?.eligibilityChoice || []
+
+      if (eligibilityChoice === 'replacement-contact') {
+        return res.redirect(`/case/${crn}/appointments/${id}/check-in/spo-approval`)
+      }
       return res.redirect(`/case/${crn}/appointments/${id}/check-in/date-frequency`)
     }
   },
@@ -248,6 +256,41 @@ const checkInsController: Controller<typeof routes, void> = {
     }
   },
 
+  getSPOApprovalPage: hmppsAuthClient => {
+    return async (req, res) => {
+      const { crn, id } = req.params as Record<string, string>
+      const { back } = req.query
+
+      await sendAuditMessage(res, 'VIEW_MAS_SPO_APPROVAL_TO_USE_CHECK_INS', crn, SubjectType.CRN)
+      if (!isValidCrn(crn) || !isValidUUID(id)) return renderError(404)(req, res)
+
+      const answer = req.session.data?.esupervision?.[crn]?.[id]?.checkins?.eligibilitySPOApproval
+      const isApproved = answer === 'spo-approval' || (Array.isArray(answer) && answer.includes('spo-approval'))
+
+      return res.render('pages/check-in/spo-approval.njk', {
+        crn,
+        id,
+        back,
+        isApproved,
+      })
+    }
+  },
+
+  postSPOApprovalPage: hmppsAuthClient => {
+    return async (req, res) => {
+      const { crn, id } = req.params as Record<string, string>
+      const { data } = req.session
+      if (!isValidCrn(crn) || !isValidUUID(id)) {
+        return renderError(404)(req, res)
+      }
+      const approval = req.body?.esupervision?.[crn]?.[id]?.checkins?.eligibilitySPOApproval
+      if (approval) {
+        setDataValue(data, ['esupervision', crn, id, 'checkins', 'eligibilitySPOApproval'], approval)
+      }
+      return res.redirect(`/case/${crn}/appointments/${id}/check-in/date-frequency`)
+    }
+  },
+
   getDateFrequencyPage: hmppsAuthClient => {
     return async (req, res) => {
       const { crn, id } = req.params as Record<string, string>
@@ -262,7 +305,7 @@ const checkInsController: Controller<typeof routes, void> = {
       if (cya) {
         backLink = `/case/${crn}/appointments/${id}/check-in/checkin-summary`
       } else if (eligibilityArray.includes('eligibility-none')) {
-        backLink = `/case/${crn}/appointments/${id}/check-in/full-eligibility`
+        backLink = `/case/${crn}/appointments/${id}/check-in/spo-approval`
       } else {
         backLink = `/case/${crn}/appointments/${id}/check-in/supplementary-eligibility`
       }

--- a/server/middleware/validation/eSuperVision.test.ts
+++ b/server/middleware/validation/eSuperVision.test.ts
@@ -23,6 +23,7 @@ const restartContactUrl = `/case/${crn}/appointments/check-in/manage/${id}/resta
 const restartEditContactUrl = `/case/${crn}/appointments/check-in/manage/${id}/restart-edit-contact`
 const eligibilityCheckUrl = `${checkInUrl}/eligibility-check`
 const fullEligibilityUrl = `${checkInUrl}/full-eligibility`
+const spoApprovalUrl = `${checkInUrl}/spo-approval`
 const reqBase = {
   method: 'POST',
   params: { crn, id },
@@ -120,6 +121,35 @@ describe('Test eSuperVision validation', () => {
       validation.eSuperVision(req, res, next)
 
       expect(res.render).toHaveBeenCalledWith('pages/check-in/eligibility-full', expect.any(Object))
+      expect(next).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Test spo-approval (checkbox)', () => {
+    it('passes when the checkbox is checked', () => {
+      const esupervision = {
+        [crn]: {
+          [id]: {
+            checkins: {
+              eligibilitySPOApproval: 'spo-approval',
+            },
+          },
+        },
+      }
+      const req = makeReq({ url: spoApprovalUrl, body: { esupervision } })
+      const res = makeRes()
+      validation.eSuperVision(req, res, next)
+      expect(next).toHaveBeenCalled()
+    })
+
+    it('fails when the checkbox is not checked', () => {
+      const req = makeReq({
+        url: spoApprovalUrl,
+      })
+      const res = makeRes()
+      validation.eSuperVision(req, res, next)
+
+      expect(res.render).toHaveBeenCalledWith('pages/check-in/spo-approval', expect.any(Object))
       expect(next).not.toHaveBeenCalled()
     })
   })

--- a/server/middleware/validation/eSuperVision.ts
+++ b/server/middleware/validation/eSuperVision.ts
@@ -76,6 +76,19 @@ const eSuperVision: Route<void> = (req, res, next) => {
       )
     }
   }
+  const validateSPOApproval = () => {
+    if (baseUrl.includes(`/case/${crn}/appointments/${id}/check-in/spo-approval`)) {
+      render = `pages/check-in/spo-approval`
+      errorMessages = validateWithSpec(
+        req,
+        eSuperVisionValidation({
+          crn,
+          id,
+          page: 'spo-approval',
+        }),
+      )
+    }
+  }
 
   const validateDateFrequency = () => {
     if (baseUrl.includes(`/case/${crn}/appointments/${id}/check-in/date-frequency`)) {
@@ -306,6 +319,7 @@ const eSuperVision: Route<void> = (req, res, next) => {
   let errorMessages: Record<string, string> = {}
   validateEligibilityCheck()
   validateEligibilityChoice()
+  validateSPOApproval()
   validateDateFrequency()
   validateContactPreference()
   validateEditContactPreference()

--- a/server/models/ESupervision.ts
+++ b/server/models/ESupervision.ts
@@ -24,6 +24,7 @@ export interface CheckinUserDetails {
   settingsUpdated?: boolean
   eligibility?: string[]
   eligibilityChoice?: 'replacement-contact' | 'supplementary-contact'
+  eligibilitySPOApproval?: any
 }
 
 export interface ManageQuestionsSession {

--- a/server/properties/validation/eSupervision.ts
+++ b/server/properties/validation/eSupervision.ts
@@ -47,6 +47,16 @@ export const eSuperVisionValidation = (args: ESupervisionValidationArgs): Valida
         },
       ],
     },
+    [`[esupervision][${crn}][${id}][checkins][eligibilitySPOApproval]`]: {
+      optional: page !== 'spo-approval',
+      checks: [
+        {
+          validator: isNotEmpty,
+          msg: 'Select to confirm SPO approval',
+          log: 'SPO approval not confirmed',
+        },
+      ],
+    },
     [`[esupervision][${crn}][${id}][checkins][date]`]: {
       optional: page !== 'date-frequency',
       checks: [

--- a/server/routes/eSupervisionCheckins.ts
+++ b/server/routes/eSupervisionCheckins.ts
@@ -47,6 +47,17 @@ export default function eSuperVisionCheckInsRoutes(router: Router, { hmppsAuthCl
     controllers.checkIns.postSupplementaryEligibilityPage(hmppsAuthClient),
   )
 
+  router.get('/case/:crn/appointments/:id/check-in/spo-approval', [
+    controllers.checkIns.getSPOApprovalPage(hmppsAuthClient),
+  ])
+  router.post(
+    '/case/:crn/appointments/:id/check-in/spo-approval',
+    validate.eSuperVision,
+    autoStoreSessionData(hmppsAuthClient),
+    postRedirectWizard(),
+    controllers.checkIns.postSPOApprovalPage(hmppsAuthClient),
+  )
+
   router.get('/case/:crn/appointments/:id/check-in/date-frequency', [
     redirectWizard(['id'], 'setupcheckins'),
     controllers.checkIns.getDateFrequencyPage(hmppsAuthClient),

--- a/server/views/pages/check-in/spo-approval.njk
+++ b/server/views/pages/check-in/spo-approval.njk
@@ -1,0 +1,41 @@
+{% extends "../_form.njk" %}
+
+{% set title = "Check you've got approval before you sign " + case.name.forename + " up"  %}
+{% set showAnchorLink = true %}
+{% set backLink = '/case/' + crn + '/appointments/' + id + '/check-in/full-eligibility' %}
+
+{% set checkboxTitle = "Confirm approval" %}
+{% block form %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+
+            <p class="govuk-body">You must have approval from your Senior Probation Officer (SPO) to sign someone up to reduce some face-to-face contact. You must only replace some face-to-face meetings. You cannot use online check ins to replace all face-to-face contact with a person.  </p>
+
+
+            {{ govukCheckboxes({
+                name: "esupervision[" + crn + "][" + id + "][checkins][eligibilitySPOApproval]",
+                idPrefix: "esupervision-" + crn + "-" + id + "-checkins-eligibilitySPOApproval",
+                fieldset: {
+                    legend: {
+                        text: checkboxTitle,
+                        isPageHeading: false,
+                        classes: "govuk-fieldset__legend--m"
+                    }
+                },
+                errorMessage: {
+                  text: errorMessages["esupervision-" + crn + "-" + id + "-checkins-eligibilitySPOApproval"]
+                } if errorMessages["esupervision-" + crn + "-" + id + "-checkins-eligibilitySPOApproval"],
+                items: [
+                {
+                  value: "spo-approval",
+                  text: "I can confirm that my SPO has approved the use of online check ins to replace some face-to-face contact with this person",
+                  label: {
+                    classes: "govuk-!-width-three-quarters"
+                  },
+                  checked: isApproved
+                }  
+            ]
+            }) | decorateFormAttributes(['esupervision', crn, id, 'checkins', 'eligibilitySPOApproval']) }}
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
[ESUP-1608](https://dsdmoj.atlassian.net/browse/ESUP-1608)

This PR adds a new SPO approval page to the set up online check ins journey. 
During the eligibility check, if the PoP is fully eligible, the practitioner then has to select how they want to use online check ins. If they select that they want 'To replace some face-to-face contact' with online check ins (as shown in the screenshot below)...
<img width="775" height="254" alt="image" src="https://github.com/user-attachments/assets/1ebe0903-e935-43a6-8f2c-4958ae24403b" />


...they are then taken to a page which asks them to confirm they have SPO approval. They must check this box to continue.


<img width="1130" height="582" alt="image" src="https://github.com/user-attachments/assets/0a95b693-810c-4cd6-886c-9828964d00bd" />


We aren't currently storing this anywhere, and this functionality is just redirecting users to the next step as long as they click the checkbox, otherwise we trigger validation:




<img width="1146" height="748" alt="image" src="https://github.com/user-attachments/assets/b53dd5be-bbe1-4087-a16d-2e38970d4742" />



There may be a future iteration on this where we save this data to our API but for now we aren't letting the practitioners proceed without the SPO approval checked.

This page does not appear if the user selects 'As well as existing face-to-face contact' in eligibility check.




[ESUP-1608]: https://dsdmoj.atlassian.net/browse/ESUP-1608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ