### PR TITLE
slack_failure_results is now in github-shared-actions

### DIFF
--- a/.github/workflows/pipeline_scan.yml
+++ b/.github/workflows/pipeline_scan.yml
@@ -167,7 +167,7 @@ jobs:
           path: results.txt
       - name: send a failure slack message
         if: steps.veracode-pipeline-scan.outcome == 'failure' && inputs.channel_id != 'NO_SLACK'
-        uses: ministryofjustice/hmpps-github-actions/.github/actions/slack_failure_results@v2 # WORKFLOW_VERSION
+        uses: ministryofjustice/hmpps-github-shared-actions/.github/actions/slack_failure_results@fddc5f11d6a8ce9b82a06fe76268835bfd99bcd4 # v1
         with:
           SLACK_BOT_TOKEN: ${{ secrets.HMPPS_SRE_SLACK_BOT_TOKEN }}
           channel_id: ${{ inputs.channel_id }}

--- a/.github/workflows/policy_scan.yml
+++ b/.github/workflows/policy_scan.yml
@@ -147,7 +147,7 @@ jobs:
           path: output.txt
       - name: send a failure slack message
         if: failure()  && inputs.channel_id != 'NO_SLACK'
-        uses: ministryofjustice/hmpps-github-shared-actions/.github/actions/slack_failure_results@7277152a31c152f8d65ccdea0df7cceca7ab3856 # v1
+        uses: ministryofjustice/hmpps-github-shared-actions/.github/actions/slack_failure_results@fddc5f11d6a8ce9b82a06fe76268835bfd99bcd4 # v1
         with:
           SLACK_BOT_TOKEN: ${{ secrets.HMPPS_SRE_SLACK_BOT_TOKEN }}
           channel_id: ${{ inputs.channel_id }}


### PR DESCRIPTION
We've migrated shared actions (referred to by workflows) from hmpps-github-actions to hmpps-github-shared-actions; this will further enable us to remove the old actions.