### PR TITLE
QA - additional questions for online check ins

### DIFF
--- a/integration_tests/e2e/appointments/check-ins.cy.ts
+++ b/integration_tests/e2e/appointments/check-ins.cy.ts
@@ -39,6 +39,7 @@ const loadPage = () => {
   cy.task('resetMocks')
   cy.visit(`/case/X000001/appointments`)
   cy.task('stubGetQuestionsTemplates')
+  cy.task('stubEnableESupervisionCustomQuestions')
 }
 
 const clickNextDayButton = () => {
@@ -850,6 +851,7 @@ context('check-ins error scenario ', () => {
 context('check-ins overview and manage pages', () => {
   it('should show online check ins section with check in details', () => {
     cy.task('resetMocks')
+    cy.task('stubEnableESupervisionCustomQuestions')
     cy.visit(`/case/X778160`)
     const overviewPage = new OverviewPage()
     overviewPage.checkOnPage()
@@ -870,6 +872,7 @@ context('check-ins overview and manage pages', () => {
 
   it('should show online check ins due section ', () => {
     cy.task('resetMocks')
+    cy.task('stubEnableESupervisionCustomQuestions')
     cy.visit(`/case/X000001`)
     const overviewPage = new OverviewPage()
     overviewPage.checkOnPage()
@@ -888,7 +891,7 @@ context('check-ins overview and manage pages', () => {
 
   it('should show checkin details', () => {
     cy.task('resetMocks')
-
+    cy.task('stubEnableESupervisionCustomQuestions')
     cy.visit(`/case/X778160/appointments`)
     const appointmentsPage = new AppointmentsPage()
     appointmentsPage.checkOnPage()
@@ -911,8 +914,8 @@ context('check-ins overview and manage pages', () => {
 
     manageCheckins.checkOnPage()
     manageCheckins.getElementData('checkinSettingsCard').should('contain.text', 'Check in settings')
-    manageCheckins.getElementData('firstCheckInDueLabel').should('contain.text', 'First check in')
-    manageCheckins.getElementData('firstCheckInValue').should('contain.text', 'Monday 3 November')
+    manageCheckins.getElementData('firstCheckInDueLabel').should('contain.text', 'Next check in')
+    manageCheckins.getElementData('firstCheckInValue').should('contain.text', 'Monday 20 April')
     manageCheckins.getElementData('frequencyLabel').should('contain.text', 'Frequency')
     manageCheckins.getElementData('frequencyValue').should('contain.text', 'Every week')
     manageCheckins.getElementData('checkinSettingsCard').find('.govuk-link').should('contain.text', 'Change')

--- a/server/controllers/check-ins.ts
+++ b/server/controllers/check-ins.ts
@@ -1,22 +1,13 @@
 import { v4 as uuidv4 } from 'uuid'
 import { DateTime } from 'luxon'
 import { Controller } from '../@types'
-import {
-  dateWithDayAndWithYear,
-  dayOfWeek,
-  getDataValue,
-  handleQuotes,
-  isValidCrn,
-  isValidUUID,
-  setDataValue,
-} from '../utils'
+import { dateWithYear, dayOfWeek, getDataValue, handleQuotes, isValidCrn, isValidUUID, setDataValue } from '../utils'
 import { renderError } from '../middleware'
 import MasApiClient from '../data/masApiClient'
 import { PersonalDetails, PersonalDetailsUpdateRequest } from '../data/model/personalDetails'
 import {
   CheckinScheduleRequest,
   DeactivateOffenderRequest,
-  EsupervisionAssignQuestionsRequest,
   ESupervisionCheckIn,
   ESupervisionNote,
   ESupervisionReview,
@@ -716,8 +707,12 @@ const checkInsController: Controller<typeof routes, void> = {
           savedUserDetails.preferredComs === 'EMAIL' ? savedUserDetails.checkInEmail : savedUserDetails.checkInMobile,
         displayDay: dayOfWeek(DateTime.fromFormat(savedUserDetails.date, 'd/M/yyyy').toFormat('yyyy-MM-dd')),
       }
+      const today = DateTime.now().startOf('day')
+      const checkInDate = DateTime.fromFormat(userDetails.date, 'd/M/yyyy').startOf('day')
+      const isFutureCheckinDate = checkInDate > today
+
       await sendAuditMessage(res, 'VIEW_MAS_CHECK_IN_CONFIRMATION', crn, SubjectType.CRN)
-      return res.render('pages/check-in/confirmation.njk', { crn, id, userDetails })
+      return res.render('pages/check-in/confirmation.njk', { crn, id, userDetails, isFutureCheckinDate })
     }
   },
 
@@ -779,7 +774,7 @@ const checkInsController: Controller<typeof routes, void> = {
         res.locals.success = true
         const forename = personalDetails?.name?.forename || 'the person'
         const rawCheckinDate = upcomingCheckin?.expectedCheckinDate
-        const nextCheckinDate = dateWithDayAndWithYear(rawCheckinDate)
+        const nextCheckinDate = dateWithYear(rawCheckinDate)
         successMessageHtml = `
           <strong>You have added additional questions to ${forename}’s next online check in</strong>
           <br>
@@ -1390,12 +1385,14 @@ const checkInsController: Controller<typeof routes, void> = {
         'manageQuestions',
         'questionTemplateAndInputs',
       ])
+      let expectedCheckinDate = getDataValue(data, ['esupervision', crn, id, 'manageQuestions', 'expectedCheckinDate'])
       // Fetch current check in questions if they have already been submitted
       if (!questionTemplateAndInputs) {
         questionTemplateAndInputs = {}
         try {
           const eSupClient = new ESupervisionClient(token)
           const response = await eSupClient.getUpcomingCheckinQuestionItems(crn, 'en-GB')
+          expectedCheckinDate = response?.upcoming?.expectedCheckinDate
           const items = response?.upcoming?.items || []
 
           items.forEach((item: any) => {
@@ -1419,6 +1416,7 @@ const checkInsController: Controller<typeof routes, void> = {
           ['esupervision', crn, id, 'manageQuestions', 'questionTemplateAndInputs'],
           questionTemplateAndInputs,
         )
+        setDataValue(data, ['esupervision', crn, id, 'manageQuestions', 'expectedCheckinDate'], expectedCheckinDate)
       }
 
       const addedQuestions = Object.entries(questionTemplateAndInputs)
@@ -1444,6 +1442,7 @@ const checkInsController: Controller<typeof routes, void> = {
         case: personalDetails,
         addedQuestions,
         data,
+        expectedCheckinDate,
       })
     }
   },

--- a/server/models/ESupervision.ts
+++ b/server/models/ESupervision.ts
@@ -30,6 +30,7 @@ export interface ManageQuestionsSession {
   availableTemplates?: EsupervisionQuestionTemplatesList[]
   questionTemplateAndInputs?: Record<string, string>
   draftQuestionInput?: string
+  expectedCheckinDate?: string
 }
 export interface LocalParams {
   crn: string

--- a/server/views/pages/check-in/confirmation.njk
+++ b/server/views/pages/check-in/confirmation.njk
@@ -43,9 +43,11 @@
         </p>
       <p class="govuk-body">You will get an email when they have submitted a check in or if they miss a check in. The email will include a link to review the check in or add any actions you will take for a missed check in.</p>
       {% if flags.enableESupervisionCustomQuestions === true %}
-      <h2 class="govuk-heading-m govuk-!-margin-top-6">Add additional questions to {{case.name.forename}}'s online check in</h2>
-      <p class="govuk-body">You can add up to 3 additional questions to {{case.name.forename}}'s next online check in, you will have until 23:59 the day before the next check in to add questions. We will send you a reminder before their next check in.</p>
-      <p class="govuk-body"><a class="govuk-link" data-qa="add-additional-questions" href="{{questionsStartPage}}">Add additional questions to {{case.name.forename}}'s first online check in</a></p>
+        {% if isFutureCheckinDate %}
+          <h2 class="govuk-heading-m govuk-!-margin-top-6">Add additional questions to {{case.name.forename}}'s online check in</h2>
+          <p class="govuk-body">You can add up to 3 additional questions to each of {{case.name.forename}}'s online check ins. You will have until 23:59 the day before the next check in to add questions. We will send you a reminder before their next check in.</p>
+          <p class="govuk-body"><a class="govuk-link" data-qa="add-additional-questions" href="{{questionsStartPage}}">Add additional questions to {{case.name.forename}}'s first online check in</a></p>
+        {% endif %}
       {% endif %}
     </div>
   </div>

--- a/server/views/pages/check-in/manage/manage-checkin.njk
+++ b/server/views/pages/check-in/manage/manage-checkin.njk
@@ -39,8 +39,18 @@
 
 {% block pageContent %}
   {% if offenderCheckinsByCRNResponse.status === 'VERIFIED' %}
-      {% set checkinLabel = 'First check in' %}
-      {% set checkinText = offenderCheckinsByCRNResponse.firstCheckin | dateWithDayAndWithoutYear %}
+      {% if flags.enableESupervisionCustomQuestions === true %}
+          {% set checkinLabel = 'Next check in' %}
+          {% if upcomingCheckin and upcomingCheckin.expectedCheckinDate %}
+              {% set checkinText = upcomingCheckin.expectedCheckinDate | dateWithDayAndWithoutYear %}
+          {% else %}
+              {% set checkinText = offenderCheckinsByCRNResponse.firstCheckin | dateWithDayAndWithoutYear %}
+          {% endif %}
+          
+      {% else %}
+          {% set checkinLabel = 'First check in' %}
+          {% set checkinText = offenderCheckinsByCRNResponse.firstCheckin | dateWithDayAndWithoutYear %}
+      {% endif %}
         {% if flags.enableManageCheckins === true %}
             <div class="moj-button-group__item">
                 <a href="{{ stopCheckinLink }}" class="govuk-button govuk-button--warning govuk-!-margin-left"  data-qa="stop-checkin-btn" >Stop online check ins</a>

--- a/server/views/pages/check-in/questions/add-questions.njk
+++ b/server/views/pages/check-in/questions/add-questions.njk
@@ -10,7 +10,7 @@
 {% set buttonText = "Save questions" %}
 {% set previewFeelingPageLink = "/case/"+  crn + "/appointments/check-in/manage/" + id + "/questions/preview/feeling" %}
 {% set previewSupportPageLink = "/case/"+  crn + "/appointments/check-in/manage/" + id + "/questions/preview/support" %}
-
+{% set expectedCheckinDateValue = expectedCheckinDate | dateWithYear %}
 
 {% block primary %}
 
@@ -65,7 +65,7 @@
         <div class="govuk-grid-column-two-thirds">
 
             <h2 class="govuk-heading-m">Additional questions</h2>
-            <p class="govuk-body">You can add up to 3 questions to {{case.name.forename}}'s online check in. These will only apply to their next online check in.</p>
+            <p class="govuk-body">You can add up to 3 questions to {{case.name.forename}}'s online check in. These will only apply to their next online check in on {{expectedCheckinDateValue}}.</p>
         </div>
     </div>
     <div class="govuk-grid-row">

--- a/server/views/pages/check-in/questions/edit-question.njk
+++ b/server/views/pages/check-in/questions/edit-question.njk
@@ -13,6 +13,7 @@
 {% block form %}
 
   {% set detailsHtml %}
+  <div class="govuk-!-width-two-thirds">
     <p class="govuk-body"><b>You should:</b></p>
     <ul class="govuk-list govuk-list--bullet">
       <li>consider if a question is appropriate for an online service</li>
@@ -21,9 +22,7 @@
       <li>avoid using complicated language or words that have a simpler alternative</li>
       <li>check spelling and grammar</li>
     </ul>
-    <p class="govuk-body"><br>For example:</p>
-    <p class="govuk-body">Have you been able to follow up with the housing service we referred you to recently?</p>
-    <p class="govuk-body">Have you been able to book a doctor’s appointment?</p>
+  </div>
   {% endset %}
 
   {{ govukDetails({

--- a/server/views/pages/check-in/questions/preview/support.njk
+++ b/server/views/pages/check-in/questions/preview/support.njk
@@ -56,7 +56,7 @@
                     <div class="govuk-checkboxes__item">
                         <input class="govuk-checkboxes__input" id="no-help-checkbox" name="assistance" type="checkbox" readonly disabled>
                         <label class="govuk-label govuk-checkboxes__label" for="no-help-checkbox">
-                            No, I do not need help
+                            No, I do not need any support
                         </label>
                     </div>
 


### PR DESCRIPTION
This PR has a few fixes for the online check in journey based on QA feedback.

QA fixes:
[ESUP-1616](https://dsdmoj.atlassian.net/browse/ESUP-1616) - Check in settings card should now show 'Next check in' instead of 'First check in'
[ESUP-1454](https://dsdmoj.atlassian.net/browse/ESUP-1454) - adjust length of the text in the bullet points to match Figma. Remove the example for now as we will be creating custom examples per template question in a future iteration.
[ESUP-1443](https://dsdmoj.atlassian.net/browse/ESUP-1443) - adjust “No, I do not need help” to “No, I do not need any support”. Also show the next check in date in the add questions page.
[ESUP-1457](https://dsdmoj.atlassian.net/browse/ESUP-1457) - adjust formatting of the date in the success banner once questions are saved.
[ESUP-1438](https://dsdmoj.atlassian.net/browse/ESUP-1438) - adjust confirmation page's content as well as logic to only show the additional questions section if the first check in date is not today.



[ESUP-1616]: https://dsdmoj.atlassian.net/browse/ESUP-1616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ESUP-1454]: https://dsdmoj.atlassian.net/browse/ESUP-1454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ESUP-1443]: https://dsdmoj.atlassian.net/browse/ESUP-1443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ESUP-1457]: https://dsdmoj.atlassian.net/browse/ESUP-1457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ESUP-1438]: https://dsdmoj.atlassian.net/browse/ESUP-1438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ