### PR TITLE
Man 2301 update deeplinks

### DIFF
--- a/integration_tests/e2e/appointments/manage-appointment/manage-appointment.cy.ts
+++ b/integration_tests/e2e/appointments/manage-appointment/manage-appointment.cy.ts
@@ -160,5 +160,55 @@ describe('Manage an appointment', () => {
       appointmentDetails(false)
       checkRescheduleLink(false)
     })
+    describe('enableDeepLinks feature flag is enabled', () => {
+      describe('drug test appointment type', () => {
+        beforeEach(() => {
+          cy.task('stubEnableDeepLinks')
+          cy.task('stubAppointment', { deliusManaged: true, contactType: 'Drug Test Appointment (NS)' })
+          loadPage()
+          manageAppointmentPage = new ManageAppointmentPage()
+        })
+        it('should display the drug history deep link with correct wording', () => {
+          manageAppointmentPage
+            .getAppointmentDetails()
+            .find('.govuk-body')
+            .should('contain.text', 'You can manage this appointment through the')
+          manageAppointmentPage
+            .getAppointmentDetails()
+            .find('.govuk-body a')
+            .should('contain.text', "person's drug history in NDelius (opens in a new tab)")
+            .should('have.attr', 'target', '_blank')
+            .should(
+              'have.attr',
+              'href',
+              `https://ndelius-dummy-url/NDelius-war/delius/JSP/deeplink.xhtml?component=DrugHistory&CRN=${crn}&EventNumber=7654321`,
+            )
+        })
+      })
+      describe('CP/UPW appointment type', () => {
+        beforeEach(() => {
+          cy.task('stubEnableDeepLinks')
+          cy.task('stubAppointment', { deliusManaged: true, contactType: 'CP/UPW - Appointment/Attendance (NS)' })
+          loadPage()
+          manageAppointmentPage = new ManageAppointmentPage()
+        })
+        it('should display the UPW worksheet deep link with correct wording', () => {
+          manageAppointmentPage
+            .getAppointmentDetails()
+            .find('.govuk-body')
+            .should('contain.text', 'You can manage this appointment through the')
+          manageAppointmentPage
+            .getAppointmentDetails()
+            .find('.govuk-body a')
+            .should('contain.text', 'unpaid work worksheet summary in NDelius (opens in a new tab)')
+            .should('have.attr', 'target', '_blank')
+            .should(
+              'have.attr',
+              'href',
+              `https://ndelius-dummy-url/NDelius-war/delius/JSP/deeplink.xhtml?component=UPWWorksheet&CRN=${crn}&EventNumber=7654321`,
+            )
+        })
+      })
+    })
   })
 })

--- a/server/data/model/featureFlags.ts
+++ b/server/data/model/featureFlags.ts
@@ -19,4 +19,5 @@ export class FeatureFlags {
   enableMopCookiePolicy?: boolean = undefined
   enableMopPrivacyPolicy?: boolean = undefined
   enableSentencePlanUrl?: boolean = undefined
+  enableDeepLinks?: boolean = undefined
 }

--- a/server/utils/deliusDeepLinkUrl.test.ts
+++ b/server/utils/deliusDeepLinkUrl.test.ts
@@ -35,6 +35,22 @@ describe('utils/deliusDeepLinkUrl', () => {
       'component-id',
       'https://ndelius-dummy-url/NDelius-war/delius/JSP/deeplink.xhtml?component=ContactList&CRN=1234&contactID=contact-id&componentId=component-id',
     ],
+    [
+      'DrugHistory',
+      'DrugHistory',
+      '1234',
+      '1',
+      undefined,
+      'https://ndelius-dummy-url/NDelius-war/delius/JSP/deeplink.xhtml?component=DrugHistory&CRN=1234&EventNumber=1',
+    ],
+    [
+      'UPWWorksheet',
+      'UPWWorksheet',
+      '1234',
+      '1',
+      undefined,
+      'https://ndelius-dummy-url/NDelius-war/delius/JSP/deeplink.xhtml?component=UPWWorksheet&CRN=1234&EventNumber=1',
+    ],
   ])(
     '%s deliusDeepLinkUrl(%s, %s)',
     (_: string, a: string, b: string, c: string | undefined, d: string | undefined, expected: string) => {

--- a/server/utils/deliusDeepLinkUrl.ts
+++ b/server/utils/deliusDeepLinkUrl.ts
@@ -10,7 +10,7 @@ export const deliusDeepLinkUrl = (component: string, crn: string, contactId?: st
   return `${config.delius.link}/NDelius-war/delius/JSP/deeplink.xhtml?component=${component}&CRN=${crn}${idParam}${componentIdParam}`
 }
 
-export const drugHistoryContactTypes = [
+export const deepLinkContactTypes = [
   'CP/UPW - Appointment/Attendance (NS)',
   'Drug Test (Approved Premises)',
   'Drug Test (DRR)',

--- a/server/utils/deliusDeepLinkUrl.ts
+++ b/server/utils/deliusDeepLinkUrl.ts
@@ -4,7 +4,19 @@ export const deliusDeepLinkUrl = (component: string, crn: string, contactId?: st
   if (!component || !crn) {
     return ''
   }
-  const contactIdParam = contactId ? `&contactID=${contactId}` : ''
+  const idParamKey = component === 'DrugHistory' || component === 'UPWWorksheet' ? 'EventNumber' : 'contactID'
+  const idParam = contactId ? `&${idParamKey}=${contactId}` : ''
   const componentIdParam = componentId ? `&componentId=${componentId}` : ''
-  return `${config.delius.link}/NDelius-war/delius/JSP/deeplink.xhtml?component=${component}&CRN=${crn}${contactIdParam}${componentIdParam}`
+  return `${config.delius.link}/NDelius-war/delius/JSP/deeplink.xhtml?component=${component}&CRN=${crn}${idParam}${componentIdParam}`
 }
+
+export const drugHistoryContactTypes = [
+  'CP/UPW - Appointment/Attendance (NS)',
+  'Drug Test (Approved Premises)',
+  'Drug Test (DRR)',
+  'Drug Test (Licence Condition)',
+  'Drug Test Details',
+  'Drug Testing Referral',
+  'Drug Testing Assessment',
+  'Drug Test Appointment (NS)',
+]

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -21,7 +21,7 @@ import {
   dateWithYearShortMonthAndTime,
   deliusDateFormat,
   deliusDeepLinkUrl,
-  drugHistoryContactTypes,
+  deepLinkContactTypes,
   fromIsoDateToPicker,
   fullName,
   getCurrentRisksToThemselves,
@@ -186,7 +186,7 @@ export default function nunjucksSetup(
   njkEnv.addGlobal('addressToList', addressToList)
   njkEnv.addGlobal('lastUpdatedBy', lastUpdatedBy)
   njkEnv.addGlobal('deliusDeepLinkUrl', deliusDeepLinkUrl)
-  njkEnv.addGlobal('drugHistoryContactTypes', drugHistoryContactTypes)
+  njkEnv.addGlobal('deepLinkContactTypes', deepLinkContactTypes)
   njkEnv.addGlobal('oaSysUrl', oaSysUrl)
   njkEnv.addGlobal('deliusHomepageUrl', deliusHomepageUrl)
   njkEnv.addGlobal('scheduledAppointments', scheduledAppointments)

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -21,6 +21,7 @@ import {
   dateWithYearShortMonthAndTime,
   deliusDateFormat,
   deliusDeepLinkUrl,
+  drugHistoryContactTypes,
   fromIsoDateToPicker,
   fullName,
   getCurrentRisksToThemselves,
@@ -185,6 +186,7 @@ export default function nunjucksSetup(
   njkEnv.addGlobal('addressToList', addressToList)
   njkEnv.addGlobal('lastUpdatedBy', lastUpdatedBy)
   njkEnv.addGlobal('deliusDeepLinkUrl', deliusDeepLinkUrl)
+  njkEnv.addGlobal('drugHistoryContactTypes', drugHistoryContactTypes)
   njkEnv.addGlobal('oaSysUrl', oaSysUrl)
   njkEnv.addGlobal('deliusHomepageUrl', deliusHomepageUrl)
   njkEnv.addGlobal('scheduledAppointments', scheduledAppointments)

--- a/server/views/pages/appointments/_outcome-details.njk
+++ b/server/views/pages/appointments/_outcome-details.njk
@@ -20,6 +20,16 @@
 </ul>
 {% endset %}
 
+{% if flags.enableDeepLinks and appointment.type in deepLinkContactTypes and appointment.eventNumber %}
+  {% if appointment.type === 'CP/UPW - Appointment/Attendance (NS)' %}
+    {% set changeUrl = deliusDeepLinkUrl('UPWWorksheet', crn, appointment.eventNumber) %}
+  {% else %}
+    {% set changeUrl = deliusDeepLinkUrl('DrugHistory', crn, appointment.eventNumber) %}
+  {% endif %}
+{% else %}
+  {% set changeUrl = changeUrl %}
+{% endif %}
+
 {% set notes = '' %}
 {% set hasNote = appointment.appointmentNote %}
 {% set hasNotes = appointment.appointmentNotes.length > 0 %}
@@ -41,7 +51,7 @@
           {
             classes: "govuk-link--no-visited-state",
             attributes: { "target": "_blank", "aria-label":"Change complied for '" + appointment.type | lower + " on NDelius" },
-            href: deliusDeepLinkUrl('UpdateContact', crn, appointment.id),
+            href: changeUrl,
             text:'Change',
             visuallyHiddenText: '(opens in new tab)'
           }
@@ -56,7 +66,7 @@
           {
             classes: "govuk-link--no-visited-state",
             attributes: { "target": "_blank", "aria-label":"Change reason for absence for '" + appointment.type | lower + " on NDelius" },
-            href: deliusDeepLinkUrl('UpdateContact', crn, appointment.id),
+            href: changeUrl,
             text:'Change',
             visuallyHiddenText: '(opens in new tab)'
           }
@@ -71,7 +81,7 @@
           {
             classes: "govuk-link--no-visited-state",
             attributes: { "target": "_blank", "aria-label":"Change enforcement action for '" + appointment.type | lower + " on NDelius" },
-            href: deliusDeepLinkUrl('UpdateContact', crn, appointment.id),
+            href: changeUrl,
             text:'Change',
             visuallyHiddenText: '(opens in new tab)'
           }
@@ -92,7 +102,7 @@
       actions: {
         items: [
           {
-            html:'<a class="govuk-link govuk-link--no-visited-state" target="_blank" href="'+ deliusDeepLinkUrl('UpdateContact', crn, appointment.id) +'"aria-label="Change uploaded documents for ' + appointment.type | lower + 'appointment on NDelius">Change<span class="govuk-visually-hidden"> (opens in new tab)</span></a>'
+            html:'<a class="govuk-link govuk-link--no-visited-state" target="_blank" href="'+ changeUrl +'"aria-label="Change uploaded documents for ' + appointment.type | lower + 'appointment on NDelius">Change<span class="govuk-visually-hidden"> (opens in new tab)</span></a>'
           }
         ]
       }

--- a/server/views/pages/appointments/manage-appointment.njk
+++ b/server/views/pages/appointments/manage-appointment.njk
@@ -218,7 +218,7 @@
           <p class="govuk-body">All links to change appointment details on NDelius open in a new tab.</p>
         {% else %}
           <p class="govuk-body">
-            {% if flags.enableDeepLinks and appointment.type in drugHistoryContactTypes %}
+            {% if flags.enableDeepLinks and appointment.type in deepLinkContactTypes and appointment.eventNumber %}
               {% if appointment.type === 'CP/UPW - Appointment/Attendance (NS)' %}
                 You can manage this appointment through the <a href="{{ deliusDeepLinkUrl('UPWWorksheet', crn, appointment.eventNumber) }}" class="govuk-link" target="_blank" rel="external noopener noreferrer">unpaid work worksheet summary in NDelius (opens in a new tab)</a>.
               {% else %}

--- a/server/views/pages/appointments/manage-appointment.njk
+++ b/server/views/pages/appointments/manage-appointment.njk
@@ -218,7 +218,16 @@
           <p class="govuk-body">All links to change appointment details on NDelius open in a new tab.</p>
         {% else %}
           <p class="govuk-body">
-            <a href="{{ deliusDeepLinkUrl('UpdateContact', crn, appointment.id) }}" class="govuk-link" target="_blank" rel="external noopener noreferrer">Manage this appointment on NDelius (opens in a new tab)</a>.</p>
+            {% if flags.enableDeepLinks and appointment.type in drugHistoryContactTypes %}
+              {% if appointment.type === 'CP/UPW - Appointment/Attendance (NS)' %}
+                You can manage this appointment through the <a href="{{ deliusDeepLinkUrl('UPWWorksheet', crn, appointment.eventNumber) }}" class="govuk-link" target="_blank" rel="external noopener noreferrer">unpaid work worksheet summary in NDelius (opens in a new tab)</a>.
+              {% else %}
+                You can manage this appointment through the <a href="{{ deliusDeepLinkUrl('DrugHistory', crn, appointment.eventNumber) }}" class="govuk-link" target="_blank" rel="external noopener noreferrer">person's drug history in NDelius (opens in a new tab)</a>.
+              {% endif %}
+            {% else %}
+              <a href="{{ deliusDeepLinkUrl('UpdateContact', crn, appointment.id) }}" class="govuk-link" target="_blank" rel="external noopener noreferrer">Manage this appointment on NDelius (opens in a new tab)</a>.
+            {% endif %}
+          </p>
         {% endif %}
         {{ govukSummaryList({
   rows: [

--- a/server/views/pages/contact-log/_log-outcome-link.njk
+++ b/server/views/pages/contact-log/_log-outcome-link.njk
@@ -2,9 +2,21 @@
   <li><a href="/case/{{ crn }}/appointments/{{ entry.esupervisionId }}/check-in/update?back={{ url }}" data-qa="update-link">Update</a></li>
   {% elif entry.deliusManaged %}
   <li><a href="{{ link }}" rel="noopener noreferrer" class="govuk-link govuk-!-margin-right-6" data-qa="view-link">View</a></li>
-  <li><a href="{{ deliusDeepLinkUrl('UpdateContact', crn, entry.id) }}" target="_blank"
-         rel="external noopener noreferrer" class="contact-activity__manage-link" data-qa="manage-on-delius-link">Manage on NDelius<span
-          class="govuk-visually-hidden"> (opens in new tab)</span></a></li>
+  {% if flags.enableDeepLinks and entry.type in deepLinkContactTypes and entry.eventNumber %}
+    {% if entry.type === 'CP/UPW - Appointment/Attendance (NS)' %}
+      <li><a href="{{ deliusDeepLinkUrl('UPWWorksheet', crn, entry.eventNumber) }}" target="_blank"
+             rel="external noopener noreferrer" class="contact-activity__manage-link" data-qa="manage-on-delius-link">Manage on NDelius<span
+              class="govuk-visually-hidden"> (opens in new tab)</span></a></li>
+    {% else %}
+      <li><a href="{{ deliusDeepLinkUrl('DrugHistory', crn, entry.eventNumber) }}" target="_blank"
+             rel="external noopener noreferrer" class="contact-activity__manage-link" data-qa="manage-on-delius-link">Manage on NDelius<span
+              class="govuk-visually-hidden"> (opens in new tab)</span></a></li>
+    {% endif %}
+  {% else %}
+    <li><a href="{{ deliusDeepLinkUrl('UpdateContact', crn, entry.id) }}" target="_blank"
+           rel="external noopener noreferrer" class="contact-activity__manage-link" data-qa="manage-on-delius-link">Manage on NDelius<span
+            class="govuk-visually-hidden"> (opens in new tab)</span></a></li>
+  {% endif %}
 {% else %}
   <li><a href="/case/{{ crn }}/appointments/appointment/{{ entry.id }}/manage?back={{ url }}" data-qa="manage-link">Manage</a></li>
 {% endif %}

--- a/server/views/partials/manage-appointment-link.njk
+++ b/server/views/partials/manage-appointment-link.njk
@@ -6,11 +6,29 @@
                 Manage
             </a>
     {% else %}
-        <a class="govuk-link govuk-link--no-visited-state"
-               target="_blank"
-               href="{{ deliusDeepLinkUrl('UpdateContact', crn, appointment.id) }}"
-               aria-label="Manage {{ appointment.type | lower }} appointment on NDelius">
-                Manage on NDelius<span class="govuk-visually-hidden"> (opens in new tab)</span>
-        </a>
+        {% if flags.enableDeepLinks and appointment.type in drugHistoryContactTypes %}
+            {% if appointment.type === 'CP/UPW - Appointment/Attendance (NS)' %}
+                <a class="govuk-link govuk-link--no-visited-state"
+                       target="_blank"
+                       href="{{ deliusDeepLinkUrl('UPWWorksheet', crn, appointment.eventNumber) }}"
+                       aria-label="Manage {{ appointment.type | lower }} appointment on NDelius">
+                        Manage on NDelius<span class="govuk-visually-hidden"> (opens in new tab)</span>
+                </a>
+            {% else %}
+                <a class="govuk-link govuk-link--no-visited-state"
+                       target="_blank"
+                       href="{{ deliusDeepLinkUrl('DrugHistory', crn, appointment.eventNumber) }}"
+                       aria-label="Manage {{ appointment.type | lower }} appointment on NDelius">
+                        Manage on NDelius<span class="govuk-visually-hidden"> (opens in new tab)</span>
+                </a>
+            {% endif %}
+        {% else %}
+            <a class="govuk-link govuk-link--no-visited-state"
+                   target="_blank"
+                   href="{{ deliusDeepLinkUrl('UpdateContact', crn, appointment.id) }}"
+                   aria-label="Manage {{ appointment.type | lower }} appointment on NDelius">
+                    Manage on NDelius<span class="govuk-visually-hidden"> (opens in new tab)</span>
+            </a>
+        {% endif %}
     {% endif %}
 {% endmacro %}

--- a/server/views/partials/manage-appointment-link.njk
+++ b/server/views/partials/manage-appointment-link.njk
@@ -6,10 +6,11 @@
                 Manage
             </a>
     {% else %}
-        {% if flags.enableDeepLinks and appointment.type in drugHistoryContactTypes %}
+        {% if flags.enableDeepLinks and appointment.type in deepLinkContactTypes and appointment.eventNumber %}
             {% if appointment.type === 'CP/UPW - Appointment/Attendance (NS)' %}
                 <a class="govuk-link govuk-link--no-visited-state"
                        target="_blank"
+                       rel="external noopener noreferrer"
                        href="{{ deliusDeepLinkUrl('UPWWorksheet', crn, appointment.eventNumber) }}"
                        aria-label="Manage {{ appointment.type | lower }} appointment on NDelius">
                         Manage on NDelius<span class="govuk-visually-hidden"> (opens in new tab)</span>
@@ -17,6 +18,7 @@
             {% else %}
                 <a class="govuk-link govuk-link--no-visited-state"
                        target="_blank"
+                       rel="external noopener noreferrer"
                        href="{{ deliusDeepLinkUrl('DrugHistory', crn, appointment.eventNumber) }}"
                        aria-label="Manage {{ appointment.type | lower }} appointment on NDelius">
                         Manage on NDelius<span class="govuk-visually-hidden"> (opens in new tab)</span>
@@ -25,6 +27,7 @@
         {% else %}
             <a class="govuk-link govuk-link--no-visited-state"
                    target="_blank"
+                   rel="external noopener noreferrer"
                    href="{{ deliusDeepLinkUrl('UpdateContact', crn, appointment.id) }}"
                    aria-label="Manage {{ appointment.type | lower }} appointment on NDelius">
                     Manage on NDelius<span class="govuk-visually-hidden"> (opens in new tab)</span>

--- a/wiremock/mappings/flipt.json
+++ b/wiremock/mappings/flipt.json
@@ -207,6 +207,17 @@
               "updatedAt": "2026-02-26T12:00:00.000000Z",
               "rules": [],
               "rollouts": []
+            },
+            {
+              "key": "enableDeepLinks",
+              "name": "enableDeepLinks",
+              "description": "",
+              "enabled": true,
+              "type": "BOOLEAN_FLAG_TYPE",
+              "createdAt": "2026-04-10T12:00:00.000000Z",
+              "updatedAt": "2026-04-10T12:00:00.000000Z",
+              "rules": [],
+              "rollouts": []
             }
           ]
         }

--- a/wiremock/stubs/appointments.ts
+++ b/wiremock/stubs/appointments.ts
@@ -25,6 +25,7 @@ interface Args {
   outcome?: string
   inOffice?: boolean
   contactId?: string
+  contactType?: string
 }
 
 const getAppointmentStub = (
@@ -51,6 +52,7 @@ const getAppointmentStub = (
     outcome = '',
     inOffice = true,
     contactId = '6',
+    contactType = undefined,
   }: Args = {} as Args,
 ): WiremockMapping => {
   const mapping: WiremockMapping = {
@@ -230,6 +232,9 @@ const getAppointmentStub = (
   }
   if (noType) {
     mapping.response.jsonBody.appointment.type = ''
+  }
+  if (contactType) {
+    mapping.response.jsonBody.appointment.type = contactType
   }
   if (noEventId) {
     mapping.response.jsonBody.appointment.eventId = 0

--- a/wiremock/stubs/flags.ts
+++ b/wiremock/stubs/flags.ts
@@ -432,6 +432,39 @@ const stubDisableSentencePlanUrl = (): SuperAgentRequest =>
     },
   })
 
+const stubEnableDeepLinks = (): SuperAgentRequest =>
+  superagent.post('http://localhost:9091/__admin/mappings').send({
+    request: {
+      urlPathPattern: '/flipt/internal/v1/evaluation/snapshot/namespace/manage-people-on-probation-ui',
+      method: 'GET',
+    },
+    response: {
+      status: 200,
+      jsonBody: {
+        namespace: {
+          key: 'manage-people-on-probation-ui',
+        },
+        flags: [
+          ...flags.mappings[0].response.jsonBody.flags,
+          {
+            key: 'enableDeepLinks',
+            name: 'enableDeepLinks',
+            description: '',
+            enabled: true,
+            type: 'BOOLEAN_FLAG_TYPE',
+            createdAt: '2026-04-10T12:00:00.000000Z',
+            updatedAt: '2026-04-10T12:00:00.000000Z',
+            rules: [],
+            rollouts: [],
+          },
+        ],
+      },
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    },
+  })
+
 export default {
   stubNoSentencePlan,
   stubNoSanIndicator,
@@ -443,6 +476,7 @@ export default {
   stubDisableOGRS4,
   stubEnableESupervisionCustomQuestions,
   stubEnableNonCompliance,
+  stubEnableDeepLinks,
   stubDisableSentencePlanUrl,
   stubOgrs4SummaryCardEnabled,
 }


### PR DESCRIPTION
MAN-2301 

### Summary                                                        
- Introduces drugHistoryContactTypes as a named subset of deepLinkContactTypes to distinguish the 3 drug history contact types (used for "person's drug history" wording) from the fullset of 8 deep link types                                       
 
 
<img width="1430" height="887" alt="image" src="https://github.com/user-attachments/assets/7ab2dc31-b14e-4627-a177-56a742885c53" />

