### PR TITLE
MAN-2301: Deep links - update deeplinks for certain contact

### DIFF
--- a/integration_tests/e2e/appointments/appointment-detail-deep-link.cy.ts
+++ b/integration_tests/e2e/appointments/appointment-detail-deep-link.cy.ts
@@ -1,0 +1,20 @@
+describe('Appointment detail - enableDeepLinks', () => {
+  beforeEach(() => {
+    cy.task('resetMocks')
+    cy.task('stubEnableDeepLinks')
+    cy.task('stubAppointmentDeepLinkWithOutcome')
+    cy.visit('/case/X000001/activity/12')
+  })
+
+  it('should display the NDelius deep link paragraph when outcome is recorded', () => {
+    cy.get('[data-qa="outcomeDetailsCard"]').should('exist')
+    cy.get('.govuk-body a')
+      .should('contain.text', "person's drug history in NDelius (opens in a new tab)")
+      .should('have.attr', 'target', '_blank')
+      .should(
+        'have.attr',
+        'href',
+        'https://ndelius-dummy-url/NDelius-war/delius/JSP/deeplink.xhtml?component=DrugHistory&CRN=X000001&EventNumber=7654321',
+      )
+  })
+})

--- a/integration_tests/e2e/appointments/appointment-detail-deep-link.cy.ts
+++ b/integration_tests/e2e/appointments/appointment-detail-deep-link.cy.ts
@@ -8,8 +8,7 @@ describe('Appointment detail - enableDeepLinks', () => {
 
   it('should display the NDelius deep link paragraph when outcome is recorded', () => {
     cy.get('[data-qa="outcomeDetailsCard"]').should('exist')
-    cy.get('.govuk-body a')
-      .should('contain.text', "person's drug history in NDelius (opens in a new tab)")
+    cy.contains('a', "person's drug history in NDelius (opens in a new tab)")
       .should('have.attr', 'target', '_blank')
       .should(
         'have.attr',

--- a/server/utils/deliusDeepLinkUrl.ts
+++ b/server/utils/deliusDeepLinkUrl.ts
@@ -10,13 +10,13 @@ export const deliusDeepLinkUrl = (component: string, crn: string, contactId?: st
   return `${config.delius.link}/NDelius-war/delius/JSP/deeplink.xhtml?component=${component}&CRN=${crn}${idParam}${componentIdParam}`
 }
 
+export const drugHistoryContactTypes = ['Drug Test Details', 'Drug Testing Referral', 'Drug Testing Assessment']
+
 export const deepLinkContactTypes = [
   'CP/UPW - Appointment/Attendance (NS)',
   'Drug Test (Approved Premises)',
   'Drug Test (DRR)',
   'Drug Test (Licence Condition)',
-  'Drug Test Details',
-  'Drug Testing Referral',
-  'Drug Testing Assessment',
   'Drug Test Appointment (NS)',
+  ...drugHistoryContactTypes,
 ]

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -22,6 +22,7 @@ import {
   deliusDateFormat,
   deliusDeepLinkUrl,
   deepLinkContactTypes,
+  drugHistoryContactTypes,
   fromIsoDateToPicker,
   fullName,
   getCurrentRisksToThemselves,
@@ -187,6 +188,7 @@ export default function nunjucksSetup(
   njkEnv.addGlobal('lastUpdatedBy', lastUpdatedBy)
   njkEnv.addGlobal('deliusDeepLinkUrl', deliusDeepLinkUrl)
   njkEnv.addGlobal('deepLinkContactTypes', deepLinkContactTypes)
+  njkEnv.addGlobal('drugHistoryContactTypes', drugHistoryContactTypes)
   njkEnv.addGlobal('oaSysUrl', oaSysUrl)
   njkEnv.addGlobal('deliusHomepageUrl', deliusHomepageUrl)
   njkEnv.addGlobal('scheduledAppointments', scheduledAppointments)

--- a/server/views/pages/appointments/_outcome-details.njk
+++ b/server/views/pages/appointments/_outcome-details.njk
@@ -27,7 +27,7 @@
     {% set changeUrl = deliusDeepLinkUrl('DrugHistory', crn, appointment.eventNumber) %}
   {% endif %}
 {% else %}
-  {% set changeUrl = changeUrl %}
+  {% set changeUrl = deliusDeepLinkUrl('UpdateContact', crn, appointment.id) %}
 {% endif %}
 
 {% set notes = '' %}
@@ -50,13 +50,13 @@
         items: [
           {
             classes: "govuk-link--no-visited-state",
-            attributes: { "target": "_blank", "aria-label":"Change complied for '" + appointment.type | lower + " on NDelius" },
+            attributes: { "target": "_blank", "rel": "external noopener noreferrer", "aria-label":"Change complied for '" + appointment.type | lower + " on NDelius" },
             href: changeUrl,
             text:'Change',
             visuallyHiddenText: '(opens in new tab)'
           }
         ]
-      }
+      } if not flags.enableDeepLinks
     },
     {
       key: { html: '<span data-qa="acceptableAbsenceReasonLabel">Reason for absence</span>' },
@@ -65,13 +65,13 @@
         items: [
           {
             classes: "govuk-link--no-visited-state",
-            attributes: { "target": "_blank", "aria-label":"Change reason for absence for '" + appointment.type | lower + " on NDelius" },
+            attributes: { "target": "_blank", "rel": "external noopener noreferrer", "aria-label":"Change reason for absence for '" + appointment.type | lower + " on NDelius" },
             href: changeUrl,
             text:'Change',
             visuallyHiddenText: '(opens in new tab)'
           }
         ]
-      }
+      } if not flags.enableDeepLinks
     } if appointment.acceptableAbsence,
     {
       key: { html: '<span data-qa="enforcementActionLabel">Enforcement action</span>' },
@@ -80,13 +80,13 @@
         items: [
           {
             classes: "govuk-link--no-visited-state",
-            attributes: { "target": "_blank", "aria-label":"Change enforcement action for '" + appointment.type | lower + " on NDelius" },
+            attributes: { "target": "_blank", "rel": "external noopener noreferrer", "aria-label":"Change enforcement action for '" + appointment.type | lower + " on NDelius" },
             href: changeUrl,
             text:'Change',
             visuallyHiddenText: '(opens in new tab)'
           }
         ]
-      }
+      } if not flags.enableDeepLinks
     } if appointment.action,
     {
       key: { html: '<span data-qa="outcomeLabel">Outcome</span>' },
@@ -102,10 +102,10 @@
       actions: {
         items: [
           {
-            html:'<a class="govuk-link govuk-link--no-visited-state" target="_blank" href="'+ changeUrl +'"aria-label="Change uploaded documents for ' + appointment.type | lower + 'appointment on NDelius">Change<span class="govuk-visually-hidden"> (opens in new tab)</span></a>'
+            html:'<a class="govuk-link govuk-link--no-visited-state" target="_blank" rel="external noopener noreferrer" href="'+ changeUrl +'"aria-label="Change uploaded documents for ' + appointment.type | lower + 'appointment on NDelius">Change<span class="govuk-visually-hidden"> (opens in new tab)</span></a>'
           }
         ]
-      }
+      } if not flags.enableDeepLinks
     } if appointment.documents.length > 0,
     {
       key: { html: '<span data-qa="sensitiveLabel">Sensitive</span>' },

--- a/server/views/pages/appointments/_outcome-details.njk
+++ b/server/views/pages/appointments/_outcome-details.njk
@@ -102,7 +102,7 @@
       actions: {
         items: [
           {
-            html:'<a class="govuk-link govuk-link--no-visited-state" target="_blank" rel="external noopener noreferrer" href="'+ changeUrl +'"aria-label="Change uploaded documents for ' + appointment.type | lower + 'appointment on NDelius">Change<span class="govuk-visually-hidden"> (opens in new tab)</span></a>'
+            html:'<a class="govuk-link govuk-link--no-visited-state" target="_blank" rel="external noopener noreferrer" href="'+ changeUrl +'" aria-label="Change uploaded documents for ' + appointment.type | lower + ' appointment on NDelius">Change<span class="govuk-visually-hidden"> (opens in new tab)</span></a>'
           }
         ]
       } if not flags.enableDeepLinks

--- a/server/views/pages/appointments/appointment.njk
+++ b/server/views/pages/appointments/appointment.njk
@@ -41,6 +41,16 @@
     </div>
   </div>
   
+  {% if flags.enableDeepLinks and isOutcomeRecorded and appointment.deliusManaged %}
+    <p class="govuk-body">
+      {% if flags.enableDeepLinks and appointment.type in drugHistoryContactTypes and appointment.eventNumber %}
+        You can manage this contact through the <a href="{{ deliusDeepLinkUrl('DrugHistory', crn, appointment.eventNumber) }}" class="govuk-link" target="_blank" rel="external noopener noreferrer">person's drug history in NDelius (opens in a new tab)</a>.
+      {% else %}
+        <a href="{{ deliusDeepLinkUrl('UpdateContact', crn, appointment.id) }}" class="govuk-link" target="_blank" rel="external noopener noreferrer">Manage this appointment on NDelius (opens in a new tab)</a>.
+      {% endif %}
+    </p>
+  {% endif %}
+
   {% set appointmentDetails %}
   {% set showAction = false %}
   {% set noMargin = true %}

--- a/wiremock/stubs/activityLog.ts
+++ b/wiremock/stubs/activityLog.ts
@@ -197,7 +197,7 @@ const stubAppointmentDeepLinkWithOutcome = (): SuperAgentRequest =>
         },
         appointment: {
           id: 12,
-          type: 'Drug Test Appointment (NS)',
+          type: 'Drug Test Details',
           startDateTime: '2023-02-12T10:15:00.382936Z[Europe/London]',
           endDateTime: '2023-02-12T10:30:00.382936Z[Europe/London]',
           isSensitive: false,

--- a/wiremock/stubs/activityLog.ts
+++ b/wiremock/stubs/activityLog.ts
@@ -178,4 +178,56 @@ const stubAppointmentOutcomeWithNoNotes = (): SuperAgentRequest =>
     },
   })
 
-export default { stubAppointmentNoOutcomeWithNote, stubAppointmentOutcomeWithNote, stubAppointmentOutcomeWithNoNotes }
+const stubAppointmentDeepLinkWithOutcome = (): SuperAgentRequest =>
+  superagent.post('http://localhost:9091/__admin/mappings').send({
+    request: {
+      urlPattern: '/mas/schedule/X000001/appointment/12',
+      method: 'GET',
+    },
+    response: {
+      status: 200,
+      jsonBody: {
+        personSummary: {
+          name: {
+            forename: 'Eula',
+            surname: 'Schmeler',
+          },
+          crn: 'X000001',
+          dateOfBirth: '1979-08-18',
+        },
+        appointment: {
+          id: 12,
+          type: 'Drug Test Appointment (NS)',
+          startDateTime: '2023-02-12T10:15:00.382936Z[Europe/London]',
+          endDateTime: '2023-02-12T10:30:00.382936Z[Europe/London]',
+          isSensitive: false,
+          hasOutcome: true,
+          deliusManaged: true,
+          eventNumber: '7654321',
+          isAppointment: false,
+          appointmentNotes: [],
+          lastUpdated: '2023-03-20',
+          officer: {
+            name: {
+              forename: 'Paulie',
+              surname: 'Walnuts',
+            },
+          },
+          lastUpdatedBy: {
+            forename: 'Paul',
+            surname: 'Smith',
+          },
+        },
+      },
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    },
+  })
+
+export default {
+  stubAppointmentNoOutcomeWithNote,
+  stubAppointmentOutcomeWithNote,
+  stubAppointmentOutcomeWithNoNotes,
+  stubAppointmentDeepLinkWithOutcome,
+}


### PR DESCRIPTION
MAN-2301 

### Summary                                                        
- Introduces drugHistoryContactTypes as a named subset of deepLinkContactTypes to distinguish the 3 drug history contact types (used for "person's drug history" wording) from the fullset of 8 deep link types                                       
 
 
<img width="1430" height="887" alt="image" src="https://github.com/user-attachments/assets/7ab2dc31-b14e-4627-a177-56a742885c53" />