### PR TITLE
QA [ESUP-1608] - SPO approval fix & minor additional questions fix

### DIFF
--- a/integration_tests/e2e/appointments/check-ins.cy.ts
+++ b/integration_tests/e2e/appointments/check-ins.cy.ts
@@ -929,7 +929,7 @@ context('check-ins overview and manage pages', () => {
     manageCheckins.checkOnPage()
     manageCheckins.getElementData('checkinSettingsCard').should('contain.text', 'Check in settings')
     manageCheckins.getElementData('firstCheckInDueLabel').should('contain.text', 'Next check in')
-    manageCheckins.getElementData('firstCheckInValue').should('contain.text', 'Monday 20 April')
+    manageCheckins.getElementData('firstCheckInValue').should('contain.text', '20 April 2026')
     manageCheckins.getElementData('frequencyLabel').should('contain.text', 'Frequency')
     manageCheckins.getElementData('frequencyValue').should('contain.text', 'Every week')
     manageCheckins.getElementData('checkinSettingsCard').find('.govuk-link').should('contain.text', 'Change')

--- a/server/controllers/check-ins.ts
+++ b/server/controllers/check-ins.ts
@@ -292,11 +292,14 @@ const checkInsController: Controller<typeof routes, void> = {
       const cya = req.query.cya === 'true'
       const eligibility = req.session.data?.esupervision?.[crn]?.[id]?.checkins?.eligibility || []
       const eligibilityArray = Array.isArray(eligibility) ? eligibility : [eligibility]
+      const eligibilityChoice = req.session.data?.esupervision?.[crn]?.[id]?.checkins?.eligibilityChoice
       let backLink: string
       if (cya) {
         backLink = `/case/${crn}/appointments/${id}/check-in/checkin-summary`
-      } else if (eligibilityArray.includes('eligibility-none')) {
+      } else if (eligibilityChoice === 'replacement-contact') {
         backLink = `/case/${crn}/appointments/${id}/check-in/spo-approval`
+      } else if (eligibilityArray.includes('eligibility-none')) {
+        backLink = `/case/${crn}/appointments/${id}/check-in/full-eligibility`
       } else {
         backLink = `/case/${crn}/appointments/${id}/check-in/supplementary-eligibility`
       }

--- a/server/routes/eSupervisionCheckins.ts
+++ b/server/routes/eSupervisionCheckins.ts
@@ -48,6 +48,7 @@ export default function eSuperVisionCheckInsRoutes(router: Router, { hmppsAuthCl
   )
 
   router.get('/case/:crn/appointments/:id/check-in/spo-approval', [
+    redirectWizard(['eligibility', 'eligibilityChoice'], 'setupcheckins'),
     controllers.checkIns.getSPOApprovalPage(hmppsAuthClient),
   ])
   router.post(

--- a/server/views/pages/check-in/manage/manage-checkin.njk
+++ b/server/views/pages/check-in/manage/manage-checkin.njk
@@ -42,14 +42,14 @@
       {% if flags.enableESupervisionCustomQuestions === true %}
           {% set checkinLabel = 'Next check in' %}
           {% if upcomingCheckin and upcomingCheckin.expectedCheckinDate %}
-              {% set checkinText = upcomingCheckin.expectedCheckinDate | dateWithDayAndWithoutYear %}
+              {% set checkinText = upcomingCheckin.expectedCheckinDate | dateWithYear %}
           {% else %}
-              {% set checkinText = offenderCheckinsByCRNResponse.firstCheckin | dateWithDayAndWithoutYear %}
+              {% set checkinText = offenderCheckinsByCRNResponse.firstCheckin | dateWithYear %}
           {% endif %}
           
       {% else %}
           {% set checkinLabel = 'First check in' %}
-          {% set checkinText = offenderCheckinsByCRNResponse.firstCheckin | dateWithDayAndWithoutYear %}
+          {% set checkinText = offenderCheckinsByCRNResponse.firstCheckin | dateWithYear %}
       {% endif %}
         {% if flags.enableManageCheckins === true %}
             <div class="moj-button-group__item">
@@ -67,7 +67,7 @@
         {% endif %}
     {% endif %}
     {% if flags.enableESupervisionCustomQuestions === true %}
-        {% set nextCheckinText = upcomingCheckin.expectedCheckinDate | dateWithDayAndWithoutYear %}
+        {% set nextCheckinText = upcomingCheckin.expectedCheckinDate | dateWithYear %}
         {% set rows = [
             {
                 key: { html: '<span data-qa="nextCheckInDueLabel">Next check in</span>' },

--- a/server/views/pages/check-in/manage/manage-checkin.njk
+++ b/server/views/pages/check-in/manage/manage-checkin.njk
@@ -75,34 +75,34 @@
             }
         ] %}
         {% if upcomingCheckin %}
-        {% for item in upcomingCheckin.questions %}
-                {% set questionNumber = loop.index %}
-                {% set rows = (rows.push({
-                    key: { html: '<span data-qa="question' + questionNumber + 'Label">Question ' + questionNumber + '</span>' },
-                    value: { html: '<span data-qa="question' + questionNumber + 'Value">' + item.question + '</span>' }
-                }), rows) %}
-        {% endfor %}
-        {% endif %}
-        {% set nextCheckinQuestionsText %}
-            {{ govukSummaryList({
-                rows: rows
+            {% for item in upcomingCheckin.questions %}
+                    {% set questionNumber = loop.index %}
+                    {% set rows = (rows.push({
+                        key: { html: '<span data-qa="question' + questionNumber + 'Label">Question ' + questionNumber + '</span>' },
+                        value: { html: '<span data-qa="question' + questionNumber + 'Value">' + item.question + '</span>' }
+                    }), rows) %}
+            {% endfor %}
+            {% set nextCheckinQuestionsText %}
+                {{ govukSummaryList({
+                    rows: rows
+                }) }}
+            {% endset %}
+            {{ appSummaryCard({
+                titleText: 'Upcoming online check in',
+                headingLevel: 3,
+                classes: ['govuk-!-margin-bottom-6 app-summary-card--large-title'],
+                attributes: {'data-qa': 'checkinQuestionsCard'},
+                html: nextCheckinQuestionsText,
+                actions: {
+                    items: [
+                        {
+                            text: 'Change questions',
+                            href: changeQuestionsLink
+                        }
+                    ]
+                } if showChange and canEditQuestions
             }) }}
-        {% endset %}
-        {{ appSummaryCard({
-            titleText: 'Upcoming online check in',
-            headingLevel: 3,
-            classes: ['govuk-!-margin-bottom-6 app-summary-card--large-title'],
-            attributes: {'data-qa': 'checkinQuestionsCard'},
-            html: nextCheckinQuestionsText,
-            actions: {
-                items: [
-                    {
-                        text: 'Change questions',
-                        href: changeQuestionsLink
-                    }
-                ]
-            } if showChange and canEditQuestions
-        }) }}
+        {% endif %}
     {% endif %}
     {% set checkin %}
     {% set nextCheckin = offenderCheckinsByCRNResponse %}

--- a/server/views/pages/check-in/questions/add-questions.njk
+++ b/server/views/pages/check-in/questions/add-questions.njk
@@ -65,7 +65,7 @@
         <div class="govuk-grid-column-two-thirds">
 
             <h2 class="govuk-heading-m">Additional questions</h2>
-            <p class="govuk-body">You can add up to 3 questions to {{case.name.forename}}'s online check in. These will only apply to their next online check in on {{expectedCheckinDateValue}}.</p>
+            <p class="govuk-body">You can add up to 3 questions to {{case.name.forename}}'s online check in. These will only apply to their next online check in on <b>{{expectedCheckinDateValue}}</b>.</p>
         </div>
     </div>
     <div class="govuk-grid-row">


### PR DESCRIPTION
[ESUP-1608](https://dsdmoj.atlassian.net/browse/ESUP-1608) - SPO approval QA
Minor fixes after feedback given by QA:

SPO related:
- Back link on the date frequency page now ensures that it returns to the correct page, depending on if the user was previously on the SPO approval page, the full eligibility page, the supplementary eligibility page, or the check your answers summary page.
- Added the redirect wizard to the SPO approval page so that if a user attempts to access it without completing the eligibility pages first, it will redirect away to the start of the eligibility journey, just like the other routes


Other fixes:
- also added bold styling to the add questions page's next online check in date. QA of [esup-1443](https://dsdmoj.atlassian.net/browse/ESUP-1443)
- hide the upcoming check in summary card if the POP is deactivated. QA of [esup-1482](https://dsdmoj.atlassian.net/browse/ESUP-1482)
-  use a different date formatter in the manage check ins page to match the date format in the design (raised by Shilpa in the slack channel)
They were small fixes so thought it would be ok to include them here rather than raise their own PR, so we can also get them in the next release.

[ESUP-1608]: https://dsdmoj.atlassian.net/browse/ESUP-1608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ