### PR TITLE
MTRSB-56: Dependabot flagged CVE-2024-50399 (moderate severity) in fa…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14956,9 +14956,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.6",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.6.tgz",
-      "integrity": "sha512-3+fdZyBRVg29n4rXP0joHthhcHdPUHaIC16cuyyd1iLsuaO6Vea36MPrxgAzbZna8lhvZeRL8Bc9GP56/J9xEw==",
+      "version": "5.5.7",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.7.tgz",
+      "integrity": "sha512-LteOsISQ2GEiDHZch6L9hB0+MLoYVLToR7xotrzU0opCICBkxOPgHAy1HxAvtxfJNXDJpgAsQN30mkrfpO2Prg==",
       "funding": [
         {
           "type": "github",
@@ -14969,7 +14969,7 @@
       "dependencies": {
         "fast-xml-builder": "^1.1.4",
         "path-expression-matcher": "^1.1.3",
-        "strnum": "^2.1.2"
+        "strnum": "^2.2.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"

--- a/package.json
+++ b/package.json
@@ -265,7 +265,7 @@
     "@istanbuljs/load-nyc-config": {
       "js-yaml": "^3.14.0"
     },
-    "fast-xml-parser": "5.5.6",
+    "fast-xml-parser": "5.5.7",
     "serialize-javascript": "^7.0.3"
   }
 }


### PR DESCRIPTION
MTRSB-56

### Summary                                                                               
                                                                                        
- Bumps the fast-xml-parser npm override from 5.5.6 to 5.5.7 to address CVE-2024-50399

https://github.com/ministryofjustice/hmpps-manage-people-on-probation-ui/security/dependabot/93
  