### PR TITLE
ESUP-1620 - Update default support question to include employment and education option

### DIFF
--- a/server/utils/eSupervisionFriendlyString.ts
+++ b/server/utils/eSupervisionFriendlyString.ts
@@ -17,7 +17,7 @@ const definitions: Record<string, string> = {
   DRUGS: 'Drugs',
   HOUSING: 'Housing',
   MONEY: 'Money',
-  SUPPORT_SYSTEM: 'Support system',
+  SUPPORT_SYSTEM: 'Relationships (family, friends, partner)',
   EMPLOYMENT_EDU: 'Employment and education',
   OTHER: 'Other',
   NO_HELP: 'No, I do not need help',

--- a/server/utils/eSupervisionFriendlyString.ts
+++ b/server/utils/eSupervisionFriendlyString.ts
@@ -18,6 +18,7 @@ const definitions: Record<string, string> = {
   HOUSING: 'Housing',
   MONEY: 'Money',
   SUPPORT_SYSTEM: 'Support system',
+  EMPLOYMENT_EDU: 'Employment and education',
   OTHER: 'Other',
   NO_HELP: 'No, I do not need help',
 }

--- a/server/utils/eSupervisionFriendlyString.ts
+++ b/server/utils/eSupervisionFriendlyString.ts
@@ -20,7 +20,7 @@ const definitions: Record<string, string> = {
   SUPPORT_SYSTEM: 'Relationships (family, friends, partner)',
   EMPLOYMENT_EDU: 'Employment and education',
   OTHER: 'Other',
-  NO_HELP: 'No, I do not need help',
+  NO_HELP: 'No, I do not need any support',
 }
 
 export default function getUserFriendlyString(key: string): string {

--- a/server/views/pages/check-in/review/notes.njk
+++ b/server/views/pages/check-in/review/notes.njk
@@ -117,7 +117,7 @@
             {% endif %}
             {% if checkIn.surveyResponse.supportSystemSupport %}
                 <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">What they want us to know about their support system</dt>
+                <dt class="govuk-summary-list__key">What they want us to know about their relationships</dt>
                 <dd class="govuk-summary-list__value">{{ checkIn.surveyResponse.supportSystemSupport }}</dd>
                 <dd class="govuk-summary-list__actions"></dd>
                 </div>

--- a/server/views/pages/check-in/review/notes.njk
+++ b/server/views/pages/check-in/review/notes.njk
@@ -115,6 +115,13 @@
                 <dd class="govuk-summary-list__actions"></dd>
                 </div>
             {% endif %}
+            {% if checkIn.surveyResponse.employmentEduSupport %}
+                <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">What they want us to know about employment and education</dt>
+                <dd class="govuk-summary-list__value">{{ checkIn.surveyResponse.employmentEduSupport }}</dd>
+                <dd class="govuk-summary-list__actions"></dd>
+                </div>
+            {% endif %}
             {% if checkIn.surveyResponse.supportSystemSupport %}
                 <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">What they want us to know about their relationships</dt>

--- a/server/views/pages/check-in/view.njk
+++ b/server/views/pages/check-in/view.njk
@@ -194,7 +194,7 @@
             {% endif %}
             {% if checkIn.surveyResponse.supportSystemSupport %}
                 <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">What they want us to know about their support system</dt>
+                <dt class="govuk-summary-list__key">What they want us to know about their relationships</dt>
                 <dd class="govuk-summary-list__value">{{ checkIn.surveyResponse.supportSystemSupport }}</dd>
                 <dd class="govuk-summary-list__actions"></dd>
                 </div>

--- a/server/views/pages/check-in/view.njk
+++ b/server/views/pages/check-in/view.njk
@@ -192,6 +192,13 @@
                 <dd class="govuk-summary-list__actions"></dd>
                 </div>
             {% endif %}
+            {% if checkIn.surveyResponse.employmentEduSupport %}
+                <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">What they want us to know about employment and education</dt>
+                <dd class="govuk-summary-list__value">{{ checkIn.surveyResponse.employmentEduSupport }}</dd>
+                <dd class="govuk-summary-list__actions"></dd>
+                </div>
+            {% endif %}
             {% if checkIn.surveyResponse.supportSystemSupport %}
                 <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">What they want us to know about their relationships</dt>


### PR DESCRIPTION
[ESUP-1620](https://dsdmoj.atlassian.net/browse/ESUP-1620)

Small PR mapping a new value to a user-friendly string.

We completed work on our POP facing UI and API, to add “Employment and education” as an additional selectable option within the support question. 
During QA it was raised that in the MPOP UI the value was being returned as EMPLOYMENT_EDU in the review check in pages. This has now been mapped to "Employment and education".

Additionally "support system" has been renamed to "relationships (family, friends, partner" or just "relationships" where appropriate. And changing 'No, I do not need help', to 'No, I do not need any support'.

<img width="1329" height="761" alt="image" src="https://github.com/user-attachments/assets/db49d3bc-cc63-43a7-84eb-3b0020ce1b79" />

[ESUP-1620]: https://dsdmoj.atlassian.net/browse/ESUP-1620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ