### PR TITLE
MAN-2527 - Update link text

### DIFF
--- a/integration_tests/e2e/appointments/appointment-detail-deep-link.cy.ts
+++ b/integration_tests/e2e/appointments/appointment-detail-deep-link.cy.ts
@@ -8,7 +8,7 @@ describe('Appointment detail - enableDeepLinks', () => {
 
   it('should display the NDelius deep link paragraph when outcome is recorded', () => {
     cy.get('[data-qa="outcomeDetailsCard"]').should('exist')
-    cy.contains('a', "person's drug history in NDelius (opens in a new tab)")
+    cy.contains('a', 'drug history in NDelius (opens in a new tab)')
       .should('have.attr', 'target', '_blank')
       .should(
         'have.attr',

--- a/integration_tests/e2e/appointments/manage-appointment/manage-appointment.cy.ts
+++ b/integration_tests/e2e/appointments/manage-appointment/manage-appointment.cy.ts
@@ -176,7 +176,7 @@ describe('Manage an appointment', () => {
           manageAppointmentPage
             .getAppointmentDetails()
             .find('.govuk-body a')
-            .should('contain.text', "person's drug history in NDelius (opens in a new tab)")
+            .should('contain.text', 'drug history in NDelius (opens in a new tab)')
             .should('have.attr', 'target', '_blank')
             .should(
               'have.attr',

--- a/server/views/pages/appointments/manage-appointment.njk
+++ b/server/views/pages/appointments/manage-appointment.njk
@@ -222,7 +222,7 @@
               {% if appointment.type === 'CP/UPW - Appointment/Attendance (NS)' %}
                 You can manage this appointment through the <a href="{{ deliusDeepLinkUrl('UPWWorksheet', crn, appointment.eventNumber) }}" class="govuk-link" target="_blank" rel="external noopener noreferrer">unpaid work worksheet summary in NDelius (opens in a new tab)</a>.
               {% else %}
-                You can manage this appointment through the <a href="{{ deliusDeepLinkUrl('DrugHistory', crn, appointment.eventNumber) }}" class="govuk-link" target="_blank" rel="external noopener noreferrer">person's drug history in NDelius (opens in a new tab)</a>.
+                You can manage this appointment through the person's <a href="{{ deliusDeepLinkUrl('DrugHistory', crn, appointment.eventNumber) }}" class="govuk-link" target="_blank" rel="external noopener noreferrer">drug history in NDelius (opens in a new tab)</a>.
               {% endif %}
             {% else %}
               <a href="{{ deliusDeepLinkUrl('UpdateContact', crn, appointment.id) }}" class="govuk-link" target="_blank" rel="external noopener noreferrer">Manage this appointment on NDelius (opens in a new tab)</a>.


### PR DESCRIPTION
MAN-2527 

### Summary                                                                                                                                   

- Moves "person's" outside the anchor link on the manage appointment page so only "drug history in NDelius (opens in a new tab)" is the link text, improving clarity and accessibility