### PR TITLE
[MAN-2643] Adding back compliance page

### DIFF
--- a/integration_tests/e2e/overview.cy.ts
+++ b/integration_tests/e2e/overview.cy.ts
@@ -17,6 +17,7 @@ context('Overview', () => {
     page.getTab('risk').should('contain.text', 'Risk')
     page.getTab('sentence').should('contain.text', 'Sentence')
     page.getTab('activityLog').should('contain.text', 'Contacts')
+    page.getTab('compliance').should('contain.text', 'Compliance')
     page.getCardHeader('schedule').should('contain.text', 'Appointments')
     checkPopHeader()
     page
@@ -182,6 +183,7 @@ context('Overview', () => {
     page.getTab('risk').should('contain.text', 'Risk')
     page.getTab('sentence').should('contain.text', 'Sentence')
     page.getTab('activityLog').should('contain.text', 'Contacts')
+    page.getTab('compliance').should('contain.text', 'Compliance')
     page.getCardHeader('schedule').should('contain.text', 'Appointments')
 
     cy.get(`[data-qa=errors]`).should(

--- a/integration_tests/e2e/personalDetails.cy.ts
+++ b/integration_tests/e2e/personalDetails.cy.ts
@@ -20,6 +20,7 @@ context('Personal Details', () => {
     page.getTab('risk').should('contain.text', 'Risk')
     page.getTab('sentence').should('contain.text', 'Sentence')
     page.getTab('activityLog').should('contain.text', 'Contacts')
+    page.getTab('compliance').should('contain.text', 'Compliance')
     page.getCardHeader('contactDetails').should('contain.text', 'Contact details')
     page.getCardHeader('personalDetails').should('contain.text', 'Personal details')
     page.getCardHeader('identityNumber').should('contain.text', 'Identity numbers')

--- a/integration_tests/e2e/sentence.cy.ts
+++ b/integration_tests/e2e/sentence.cy.ts
@@ -16,6 +16,7 @@ context('Sentence', () => {
     page.getTab('risk').should('contain.text', 'Risk')
     page.getTab('sentence').should('contain.text', 'Sentence')
     page.getTab('activityLog').should('contain.text', 'Contacts')
+    page.getTab('compliance').should('contain.text', 'Compliance')
 
     page.assertAnchorElementAtIndex(
       '[class="moj-side-navigation__item moj-side-navigation__item--active"]',

--- a/server/views/pages/overview.njk
+++ b/server/views/pages/overview.njk
@@ -635,9 +635,12 @@
                     {{ overview.compliance.breachesOnCurrentOrderCount }} breaches on current order
               {%- endswitch -%}
                   {% endif %}
+
+              {% if flags.enableCompliancePage %}
                   <p>
                     <a href={{crn}}/compliance>View all compliance details</a>
                   </p>
+              {% endif %}
                   {% endset %}
                   {% set activity %}
                   {% if overview.activity %}

--- a/server/views/pages/overview.njk
+++ b/server/views/pages/overview.njk
@@ -635,6 +635,9 @@
                     {{ overview.compliance.breachesOnCurrentOrderCount }} breaches on current order
               {%- endswitch -%}
                   {% endif %}
+                  <p>
+                    <a href={{crn}}/compliance>View all compliance details</a>
+                  </p>
                   {% endset %}
                   {% set activity %}
                   {% if overview.activity %}

--- a/server/views/partials/case-nav.njk
+++ b/server/views/partials/case-nav.njk
@@ -52,6 +52,8 @@
             {% endif %}
             href="/case/{{ crn }}/activity-log">Contacts</a>
         </li>
+
+        {% if flags.enableCompliancePage %}
         <li class="moj-sub-navigation__item" data-qa="complianceTab">
           <a class="moj-sub-navigation__link govuk-link--no-visited-state"
             {% if currentNavSection == 'compliance' %}
@@ -59,6 +61,7 @@
             {% endif %}
             href="/case/{{ crn }}/compliance">Compliance</a>
         </li>
+        {% endif %}
         <li class="moj-sub-navigation__item" data-qa="interventionsTab">
           <a class="moj-sub-navigation__link govuk-link--no-visited-state"
             {% if currentNavSection == 'interventions' %}

--- a/server/views/partials/case-nav.njk
+++ b/server/views/partials/case-nav.njk
@@ -52,6 +52,13 @@
             {% endif %}
             href="/case/{{ crn }}/activity-log">Contacts</a>
         </li>
+        <li class="moj-sub-navigation__item" data-qa="complianceTab">
+          <a class="moj-sub-navigation__link govuk-link--no-visited-state"
+            {% if currentNavSection == 'compliance' %}
+            aria-current="page"
+            {% endif %}
+            href="/case/{{ crn }}/compliance">Compliance</a>
+        </li>
         <li class="moj-sub-navigation__item" data-qa="interventionsTab">
           <a class="moj-sub-navigation__link govuk-link--no-visited-state"
             {% if currentNavSection == 'interventions' %}


### PR DESCRIPTION
Revert "[MAN-2478] Remove compliance tab from the case overview page (#1384)" Revert "[MAN-2535] Remove compliance hyperlink. Related to MAN-2478 (#1386)"

[MAN-2478]: https://dsdmoj.atlassian.net/browse/MAN-2478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAN-2535]: https://dsdmoj.atlassian.net/browse/MAN-2535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ