### PR TITLE
Bugfix for styling issue caused by ESUP-1733 

### DIFF
--- a/assets/scss/components/_photo.scss
+++ b/assets/scss/components/_photo.scss
@@ -1,5 +1,3 @@
-@use 'govuk-frontend/dist/govuk/index' as gds;
-
 .es-photo-capture {
   &__wrap {
     position: relative;
@@ -108,11 +106,11 @@
 }
 
 .es-inset-text--error {
-  border-left-color: gds.$govuk-error-colour;
+  border-left-color: 	#ca3535
 }
 
 .es-heading--error {
-  color: gds.$govuk-error-colour;
+  color: 	#ca3535
 }
 
 .es-hidden {


### PR DESCRIPTION
<img width="844" height="407" alt="image" src="https://github.com/user-attachments/assets/3d1ecc8d-1127-4e66-ba5c-0626bf7d8ded" />


Alignment issue now fixed. This was caused by reimporting GDS in the file instead of relying on the import globally.