### PR TITLE
[ESUP-1776] Review check in and annotate check in uses assigned practitioner instead of logged in practitioner

### DIFF
--- a/server/controllers/check-ins.test.ts
+++ b/server/controllers/check-ins.test.ts
@@ -1912,7 +1912,6 @@ describe('checkInsController', () => {
       await controllers.checkIns.postViewCheckIn(hmppsAuthClient)(req, res)
 
       expect(postReviewNoteSpy).toHaveBeenCalled()
-      expect(getProbationPractitionerSpy).toHaveBeenCalled()
       expect(redirectSpy).toHaveBeenCalledWith(req.url)
     })
 
@@ -1958,7 +1957,6 @@ describe('checkInsController', () => {
       await controllers.checkIns.postReviewCheckIn(hmppsAuthClient)(req, res)
 
       expect(postReviewSpy).toHaveBeenCalled()
-      expect(getProbationPractitionerSpy).toHaveBeenCalled()
       expect(redirectSpy).toHaveBeenCalledWith(`/case/${req.params.crn}/activity-log`)
     })
 

--- a/server/controllers/check-ins.ts
+++ b/server/controllers/check-ins.ts
@@ -505,9 +505,7 @@ const checkInsController: Controller<typeof routes, void> = {
       }
       if (checkIn.status === 'SUBMITTED' || checkIn.status === 'EXPIRED') {
         const token = await hmppsAuthClient.getSystemClientToken(res.locals.user.username)
-        const masClient = new MasApiClient(token)
-        const pp: ProbationPractitioner = await masClient.getProbationPractitioner(crn)
-        const practitionerId = pp?.username ? pp.username : res.locals.user.username
+        const practitionerId = res.locals.user.username
         const eSupervisionClient = new ESupervisionClient(token)
         await eSupervisionClient.postOffenderCheckInStarted(id, practitionerId)
       }

--- a/server/controllers/check-ins.ts
+++ b/server/controllers/check-ins.ts
@@ -563,13 +563,11 @@ const checkInsController: Controller<typeof routes, void> = {
 
       const token = await hmppsAuthClient.getSystemClientToken(res.locals.user.username)
 
-      const masClient = new MasApiClient(token)
-      const pp: ProbationPractitioner = await masClient.getProbationPractitioner(crn)
-      const practitionerId = pp?.username ? pp.username : res.locals.user.username
+      const practitionerUsername = res.locals.user.username
 
       const eSupervisionClient = new ESupervisionClient(token)
       const notes: ESupervisionNote = {
-        updatedBy: practitionerId,
+        updatedBy: practitionerUsername,
         notes: checkIn.note,
         sensitive: checkIn?.sensitiveContact === 'true',
       }
@@ -682,15 +680,13 @@ const checkInsController: Controller<typeof routes, void> = {
       const { data } = req.session
       const checkIn = getDataValue(data, ['esupervision', crn, id, 'checkins'])
       const token = await hmppsAuthClient.getSystemClientToken(res.locals.user.username)
-      const masClient = new MasApiClient(token)
-      const pp: ProbationPractitioner = await masClient.getProbationPractitioner(crn)
-      const practitionerId = pp?.username ? pp.username : res.locals.user.username
+      const practitionerUsername = res.locals.user.username
       let risk: boolean = null
       if (checkIn?.riskManagementFeedback) {
         risk = checkIn.riskManagementFeedback === 'yes'
       }
       const review: ESupervisionReview = {
-        reviewedBy: practitionerId,
+        reviewedBy: practitionerUsername,
         manualIdCheck: checkIn?.manualIdCheck,
         missedCheckinComment: checkIn?.missedCheckinComment,
         notes: checkIn?.furtherActions,


### PR DESCRIPTION
[ESUP-1776](https://dsdmoj.atlassian.net/browse/ESUP-1776)

Bugfix to ensure whenever a logged-in user writes a review or annotates one post-review, we should record it as the logged-in user instead of the practitioner assigned to the person on probation. Using the assigned practitioner was not ideal for audit trail purposes as it was misleading.

We already had the username set as a fallback if the assigned practitioner wasn't available, so this is a small non-breaking change.


<img width="1164" height="669" alt="image" src="https://github.com/user-attachments/assets/b18de323-0c98-4105-8d52-45ea389bf7cd" />


[ESUP-1776]: https://dsdmoj.atlassian.net/browse/ESUP-1776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ