### PR TITLE
Add manual id check response

### DIFF
--- a/server/data/model/featureFlags.ts
+++ b/server/data/model/featureFlags.ts
@@ -23,4 +23,5 @@ export class FeatureFlags {
   enableMyEnforcementActionsOverview?: boolean = undefined
   enableShowNextCheckinDate?: boolean = undefined
   enableStopCheckinSensitiveFlag?: boolean = undefined
+  enableShowMatchWithConcern?: boolean = undefined
 }

--- a/server/views/pages/check-in/review/identity.njk
+++ b/server/views/pages/check-in/review/identity.njk
@@ -83,7 +83,7 @@
         </dl>
 
         <form method="post" autocomplete="off" action="{{ paths.current  }}">
-            {% if flags.enableShowNextCheckinDate === false %}
+            {% if flags.enableShowMatchWithConcern === true %}
                 {{ govukRadios({
                     fieldset: {
                         legend: {

--- a/server/views/pages/check-in/review/identity.njk
+++ b/server/views/pages/check-in/review/identity.njk
@@ -83,29 +83,62 @@
         </dl>
 
         <form method="post" autocomplete="off" action="{{ paths.current  }}">
-            {{ govukRadios({
-                fieldset: {
-                    legend: {
-                        text: 'Is the person in the image from the check in ' + checkIn.personalDetails.name.forename + '?',
-                        classes: "govuk-label--m govuk-!-font-weight-bold"
-                    }
-                },
-                formGroup: {
-                    attributes: {
-                        'data-qa': 'confirmIdentity'
-                    }
-                },
-                items: [
-                    {
-                        value: "MATCH",
-                        text: "Yes"
+            {% if flags.enableShowNextCheckinDate === false %}
+                {{ govukRadios({
+                    fieldset: {
+                        legend: {
+                            text: 'Is the person in the image from the check in ' + checkIn.personalDetails.name.forename + '?',
+                            classes: "govuk-label--m govuk-!-font-weight-bold"
+                        }
                     },
-                    {
-                        value: "NO_MATCH",
-                        text: "No"
-                    }
-                ]
-            } | decorateFormAttributes(['esupervision', crn, id, 'checkins', 'manualIdCheck'])) }}
+                    hint: {
+                        text: 'We will only save the image if it isn’t the person, or there is anything of concern, for example, evidence of crime or physical injury.'
+                    },
+                    formGroup: {
+                        attributes: {
+                            'data-qa': 'confirmIdentity'
+                        }
+                    },
+                    items: [
+                        {
+                            value: "MATCH",
+                            text: "Yes, and there is nothing concerning"
+                        },
+                        {
+                            value: "MATCH_WITH_CONCERN",
+                            text: "Yes, and there is a visible concern"
+                        },
+                        {
+                            value: "NO_MATCH",
+                            text: "No, it is not " + checkIn.personalDetails.name.forename
+                        }
+                    ]
+                } | decorateFormAttributes(['esupervision', crn, id, 'checkins', 'manualIdCheck'])) }}
+            {% else %}
+                {{ govukRadios({
+                    fieldset: {
+                        legend: {
+                            text: 'Is the person in the image from the check in ' + checkIn.personalDetails.name.forename + '?',
+                            classes: "govuk-label--m govuk-!-font-weight-bold"
+                        }
+                    },
+                    formGroup: {
+                        attributes: {
+                            'data-qa': 'confirmIdentity'
+                        }
+                    },
+                    items: [
+                        {
+                            value: "MATCH",
+                            text: "Yes"
+                        },
+                        {
+                            value: "NO_MATCH",
+                            text: "No"
+                        }
+                    ]
+                } | decorateFormAttributes(['esupervision', crn, id, 'checkins', 'manualIdCheck'])) }}
+            {% endif %}
 
             <div class="govuk-button-group">
                 {{ govukButton({

--- a/wiremock/mappings/flipt.json
+++ b/wiremock/mappings/flipt.json
@@ -253,6 +253,17 @@
               "updatedAt": "2026-05-18T12:00:00.000000Z",
               "rules": [],
               "rollouts": []
+            },
+            {
+              "key": "enableShowMatchWithConcern",
+              "name": "enableShowMatchWithConcern",
+              "description": "",
+              "enabled": true,
+              "type": "BOOLEAN_FLAG_TYPE",
+              "createdAt": "2026-05-18T12:00:00.000000Z",
+              "updatedAt": "2026-05-18T12:00:00.000000Z",
+              "rules": [],
+              "rollouts": []
             }
           ]
         }

--- a/wiremock/stubs/flags.ts
+++ b/wiremock/stubs/flags.ts
@@ -424,6 +424,17 @@ const stubEnableESupervisionCustomQuestions = (): SuperAgentRequest =>
             rules: [],
             rollouts: [],
           },
+          {
+            key: 'enableShowMatchWithConcern',
+            name: 'enableShowMatchWithConcern',
+            description: '',
+            enabled: true,
+            type: 'BOOLEAN_FLAG_TYPE',
+            createdAt: '2026-05-18T12:00:00.000000Z',
+            updatedAt: '2026-05-18T12:00:00.000000Z',
+            rules: [],
+            rollouts: [],
+          },
         ],
       },
       headers: {
@@ -650,6 +661,38 @@ const stubEnableStopCheckinSensitiveFlag = (): SuperAgentRequest =>
     },
   })
 
+const stubEnableShowMatchWithConcern = (): SuperAgentRequest =>
+  superagent.post('http://localhost:9091/__admin/mappings').send({
+    request: {
+      urlPathPattern: '/flipt/internal/v1/evaluation/snapshot/namespace/manage-people-on-probation-ui',
+      method: 'GET',
+    },
+    response: {
+      status: 200,
+      jsonBody: {
+        namespace: {
+          key: 'manage-people-on-probation-ui',
+        },
+        flags: [
+          {
+            key: 'enableShowMatchWithConcern',
+            name: 'enableShowMatchWithConcern',
+            description: '',
+            enabled: true,
+            type: 'BOOLEAN_FLAG_TYPE',
+            createdAt: '2026-05-18T12:00:00.000000Z',
+            updatedAt: '2026-05-18T12:00:00.000000Z',
+            rules: [],
+            rollouts: [],
+          },
+        ],
+      },
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    },
+  })
+
 export default {
   stubNoSentencePlan,
   stubNoSanIndicator,
@@ -668,4 +711,5 @@ export default {
   stubDisableHomePageOutcome,
   stubEnableShowNextCheckinDate,
   stubEnableStopCheckinSensitiveFlag,
+  stubEnableShowMatchWithConcern,
 }


### PR DESCRIPTION
[ESUP-1579 Update “Review and confirm identity” journey with new question wording Type](https://dsdmoj.atlassian.net/browse/ESUP-1579)

Feature flagged
This has been feature flagged so that we don't run into any delays between testing and the release day. Please let me know if you think it shouldn't be. I've set up the flag in Flipt DEV (It is visible on page 2 in Flipt).

This PR adds an extra manual id check response for a practitioner when reviewing a checkin and updates some of the text.