### PR TITLE
[ESUP-1801] - Fix errors on case page

### DIFF
--- a/server/middleware/getCheckinUpcomingDetails.test.ts
+++ b/server/middleware/getCheckinUpcomingDetails.test.ts
@@ -42,6 +42,14 @@ describe('getUpcomingCheckinDetails', () => {
         authSource: 'test',
         token: '1234',
       },
+      offenderCheckinsByCRNResponse: {
+        status: 'VERIFIED',
+        uuid: '',
+        crn: '',
+        firstCheckin: '',
+        checkinInterval: 'WEEKLY',
+        contactPreference: 'PHONE',
+      },
     }
   })
 
@@ -71,5 +79,23 @@ describe('getUpcomingCheckinDetails', () => {
     expect(mockGetUpcomingCheckinQuestions).toHaveBeenCalledWith(crn, 'en-GB')
     expect(res.locals.upcomingCheckin).toBeNull()
     expect(logger.info).toHaveBeenCalledWith(`No upcoming check in found for CRN ${crn}`)
+  })
+
+  it('checks status and if it is not VERIFIED it does not call the endpoint and returns check in as null', async () => {
+    res.locals.offenderCheckinsByCRNResponse = {
+      status: 'INITIAL',
+      uuid: '',
+      crn: '',
+      firstCheckin: '',
+      checkinInterval: 'WEEKLY',
+      contactPreference: 'PHONE',
+    }
+
+    const req = httpMocks.createRequest({ params: { crn } })
+
+    await getUpcomingCheckinDetails(hmppsAuthClient)(req, res)
+
+    expect(mockGetUpcomingCheckinQuestions).not.toHaveBeenCalled()
+    expect(res.locals.upcomingCheckin).toBeNull()
   })
 })

--- a/server/middleware/getCheckinUpcomingDetails.ts
+++ b/server/middleware/getCheckinUpcomingDetails.ts
@@ -6,7 +6,11 @@ import logger from '../../logger'
 export const getUpcomingCheckinDetails = (hmppsAuthClient: HmppsAuthClient): Route<Promise<void>> => {
   return async (req, res, next) => {
     const { crn } = req.params as Record<string, string>
-
+    const checkinStatus = res.locals.offenderCheckinsByCRNResponse?.status
+    if (checkinStatus !== 'VERIFIED') {
+      res.locals.upcomingCheckin = null
+      return
+    }
     try {
       const token = await hmppsAuthClient.getSystemClientToken(res.locals.user.username)
       const eSupervisionClient = new ESupervisionClient(token)


### PR DESCRIPTION
[ESUP-1801](https://dsdmoj.atlassian.net/browse/ESUP-1801)

This PR fixes a bug where errors were being raised because the API endpoint to retrieve online check in details was being called for POPs who weren't set up for online check ins. To fix this, we now only call this endpoint if the POP has a 'VERIFIED' status.

[ESUP-1801]: https://dsdmoj.atlassian.net/browse/ESUP-1801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ