### PR TITLE
[ESUP-1804] - use active UUID instead of stale UUID

### DIFF
--- a/server/controllers/check-ins.test.ts
+++ b/server/controllers/check-ins.test.ts
@@ -1110,6 +1110,7 @@ describe('checkInsController', () => {
     it('renders confirmation with computed displayCommsOption and displayDay', async () => {
       mockIsValidCrn.mockReturnValue(true)
       mockIsValidUUID.mockReturnValue(true)
+      const activeId = uuid
 
       const data = {
         esupervision: {
@@ -1132,6 +1133,16 @@ describe('checkInsController', () => {
         session: { data },
       })
 
+      const mockResponse = {
+        crn,
+        uuid,
+        status: 'VERIFIED',
+        firstCheckin: '2/7/2026',
+        checkinInterval: 'WEEKLY',
+        contactPreference: 'EMAIL',
+      }
+      getOffenderCheckinsByCRNSpy.mockResolvedValueOnce({ ...mockResponse, uuid: activeId } as any)
+
       await controllers.checkIns.getConfirmationPage(hmppsAuthClient)(req, res)
       checkSendAuditMessage(res, 'VIEW_MAS_CHECK_IN_CONFIRMATION', crn, SubjectType.CRN)
       expect(renderSpy).toHaveBeenCalled()
@@ -1139,7 +1150,7 @@ describe('checkInsController', () => {
       expect(template).toBe('pages/check-in/confirmation.njk')
       expect(context.crn).toBe(crn)
       expect(context.id).toBe(uuid)
-      expect(context.userDetails.uuid).toBe(uuid)
+      expect(context.userDetails.uuid).toBe(activeId)
       expect(context.userDetails.interval).toBe('Every week')
       expect(context.userDetails.displayCommsOption).toBe('person@example.com')
       expect(context.userDetails.displayDay).toBe('Wednesday')

--- a/server/controllers/check-ins.ts
+++ b/server/controllers/check-ins.ts
@@ -750,9 +750,11 @@ const checkInsController: Controller<typeof routes, void> = {
         return renderError(404)(req, res)
       }
       await postCheckinInComplete(hmppsAuthClient)(req, res)
+      await getCheckinOffenderDetails(hmppsAuthClient)(req, res)
+      const activeId = res.locals?.offenderCheckinsByCRNResponse?.uuid
       const userDetails: CheckinUserDetails = {
         ...savedUserDetails,
-        uuid: id,
+        uuid: activeId,
         interval: checkinIntervals.find(option => option.id === savedUserDetails.interval).label,
         displayCommsOption:
           savedUserDetails.preferredComs === 'EMAIL' ? savedUserDetails.checkInEmail : savedUserDetails.checkInMobile,
@@ -763,7 +765,7 @@ const checkInsController: Controller<typeof routes, void> = {
       const isFutureCheckinDate = checkInDate > today
 
       await sendAuditMessage(res, 'VIEW_MAS_CHECK_IN_CONFIRMATION', crn, SubjectType.CRN)
-      return res.render('pages/check-in/confirmation.njk', { crn, id, userDetails, isFutureCheckinDate })
+      return res.render('pages/check-in/confirmation.njk', { crn, id, activeId, userDetails, isFutureCheckinDate })
     }
   },
 

--- a/server/views/pages/check-in/confirmation.njk
+++ b/server/views/pages/check-in/confirmation.njk
@@ -10,7 +10,7 @@
 {% set overViewLink = "/case/" + crn %}
 {% set anotherAppointment = "/case/"+ crn + "/appointments/appointment/" + backendId + "/next-appointment"%}
 {% set overViewPage = "/case/" + crn %}
-{% set questionsStartPage = "/case/" + crn + "/appointments/check-in/manage/" + id + "/questions/start" %}
+{% set questionsStartPage = "/case/" + crn + "/appointments/check-in/manage/" + activeId + "/questions/start" %}
 {% set panelHtml %}
 <div class="govuk-!-font-size-36">
     Starting {{ userDetails.displayDay }}


### PR DESCRIPTION
[ESUP-1804](https://dsdmoj.atlassian.net/browse/ESUP-1804)

A bug was raised by our QA where the following occured:
- A new POP was set up for online check ins
- On the confirmation page, they clicked 'Add additional questions to X's first online check in
- They added new questions to the next check in
- They attempted to stop their use of online check ins
- An error occurred

This was happening because the confirmation page was retaining the UUID from the set up flow instead of using the POP UUID.  This edge case wasn't happening elsewhere because when we navigate to the overview page instead, we pull the correct UUID from the endpoint.

[ESUP-1804]: https://dsdmoj.atlassian.net/browse/ESUP-1804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ