### PR TITLE
[ESUP-1825] - Accessibility High Priority (external audit)

### DIFF
--- a/assets/js/photo.js
+++ b/assets/js/photo.js
@@ -61,7 +61,7 @@ const capturePhoto = async v => {
       videoContainer.appendChild(canvas)
 
       if (takePhotoButton) {
-        takePhotoButton.setAttribute('data-ready', 'true')
+        takePhotoButton.setAttribute('data-camera-ready', 'true')
         takePhotoButton.addEventListener('click', async () => {
           context.drawImage(video, 0, 0, w, h)
           const dataUrl = canvas.toDataURL(IMAGE_CONTENT_TYPE)

--- a/assets/js/photo.js
+++ b/assets/js/photo.js
@@ -61,7 +61,7 @@ const capturePhoto = async v => {
       videoContainer.appendChild(canvas)
 
       if (takePhotoButton) {
-        takePhotoButton.removeAttribute('disabled')
+        takePhotoButton.setAttribute('data-ready', 'true')
         takePhotoButton.addEventListener('click', async () => {
           context.drawImage(video, 0, 0, w, h)
           const dataUrl = canvas.toDataURL(IMAGE_CONTENT_TYPE)

--- a/integration_tests/pages/check-ins/take-a-photo.ts
+++ b/integration_tests/pages/check-ins/take-a-photo.ts
@@ -7,5 +7,5 @@ export default class TakeAPhotoPage extends Page {
 
   getBackLink = (): PageElement => cy.get('.govuk-back-link')
 
-  getSubmitBtn = (): PageElement => cy.get('[data-qa="submit-btn"]').should('have.attr', 'data-ready', 'true')
+  getSubmitBtn = (): PageElement => cy.get('[data-qa="submit-btn"]').should('have.attr', 'data-camera-ready', 'true')
 }

--- a/integration_tests/pages/check-ins/take-a-photo.ts
+++ b/integration_tests/pages/check-ins/take-a-photo.ts
@@ -6,4 +6,6 @@ export default class TakeAPhotoPage extends Page {
   }
 
   getBackLink = (): PageElement => cy.get('.govuk-back-link')
+
+  getSubmitBtn = (): PageElement => cy.get('[data-qa="submit-btn"]').should('have.attr', 'data-ready', 'true')
 }

--- a/server/views/pages/check-in/take-a-photo.njk
+++ b/server/views/pages/check-in/take-a-photo.njk
@@ -25,7 +25,6 @@
                 text: "Take photo",
                 type: "button",
                 id: "take-photo",
-                disabled: true,
                 attributes: {
                     'data-qa': 'submit-btn'
                 }


### PR DESCRIPTION
[ESUP-1825](https://dsdmoj.atlassian.net/browse/ESUP-1825)

Removes disabled attribute from take photo button in sign up to online check ins journey so that assistive technologies can announce the button correctly.

Previously, this button was disabled until the camera was live. Removing the attribute won't impact users in production, as attempts to click are ignored because the event listener isn't live yet and users will wait until they can see a face before taking a picture.

Additionally, because photo.js originally relied on removing the disabled attribute once the camera loaded, removing it from the template broke our Cypress tests by allowing an instant click on page load. To fix the tests, I've introduced a data-camera-ready="true" attribute that gets set once the camera finishes loading, and updated the Cypress page object to wait for this attribute before clicking so that the tests pass.

[ESUP-1825]: https://dsdmoj.atlassian.net/browse/ESUP-1825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ