### PR TITLE
[ESUP-1839] - Back link disappears when errors are displayed - Observation (External audit)

### DIFF
--- a/server/middleware/validation/eSuperVision.ts
+++ b/server/middleware/validation/eSuperVision.ts
@@ -93,6 +93,20 @@ const eSuperVision: Route<void> = (req, res, next) => {
   const validateDateFrequency = () => {
     if (baseUrl.includes(`/case/${crn}/appointments/${id}/check-in/date-frequency`)) {
       render = `pages/check-in/date-frequency`
+      const eligibility = req.session.data?.esupervision?.[crn]?.[id]?.checkins?.eligibility || []
+      const eligibilityArray = Array.isArray(eligibility) ? eligibility : [eligibility]
+      const eligibilityChoice = req.session.data?.esupervision?.[crn]?.[id]?.checkins?.eligibilityChoice
+      let backUrl: string
+      if (cya) {
+        backUrl = `/case/${crn}/appointments/${id}/check-in/checkin-summary`
+      } else if (eligibilityChoice === 'replacement-contact') {
+        backUrl = `/case/${crn}/appointments/${id}/check-in/spo-approval`
+      } else if (eligibilityArray.includes('eligibility-none')) {
+        backUrl = `/case/${crn}/appointments/${id}/check-in/full-eligibility`
+      } else {
+        backUrl = `/case/${crn}/appointments/${id}/check-in/supplementary-eligibility`
+      }
+      res.locals.backLink = backUrl
       errorMessages = validateWithSpec(
         req,
         eSuperVisionValidation({


### PR DESCRIPTION
[ESUP-1839](https://dsdmoj.atlassian.net/browse/ESUP-1839)

This PR adds the logic for the backlink into the validate date frequency function. The logic for the backlink is calculated in the GET route, however this is not passed to the POST route when validation occurs. When it was erroring, the backlink was coming through as undefined, and then would not show. 
This change now means that we get the correct route for the backlink based on the same logic as the GET route.

[ESUP-1839]: https://dsdmoj.atlassian.net/browse/ESUP-1839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ