### PR TITLE
[ESUP-1879] - Accessibility - 2.14 Device-specific wording may cause confusion during photo capture Observation (External audit)

### DIFF
--- a/server/views/pages/check-in/photo-options.njk
+++ b/server/views/pages/check-in/photo-options.njk
@@ -13,7 +13,7 @@
         <li>are the only person in the photo</li>
         <li>are not wearing a hat or sunglasses</li>
     </ul>
-    <p>When you've taken the photo, you'll be able to review it to make sure it meets <br/> the rules.</p>
+    <p class="govuk-body">You’ll need to accept permissions to use the camera on your laptop or device. When you’ve taken the photo, you’ll be able to review it to make sure it meets the rules.</p>
 
     {{ govukRadios({
         fieldset: {
@@ -30,7 +30,7 @@
         items: [
             {
                 value: "TAKE_A_PIC",
-                text: "Take a photo now using the laptop you're on"
+                text: "Take a photo now using the laptop or device you’re on"
             },
             {
                 value: "UPLOAD_A_PIC",

--- a/server/views/pages/check-in/photo-options.njk
+++ b/server/views/pages/check-in/photo-options.njk
@@ -13,7 +13,7 @@
         <li>are the only person in the photo</li>
         <li>are not wearing a hat or sunglasses</li>
     </ul>
-    <p class="govuk-body">You’ll need to accept permissions to use the camera on your laptop or device. When you’ve taken the photo, you’ll be able to review it to make sure it meets the rules.</p>
+    <p class="govuk-body">You'll need to accept permissions to use the camera on your laptop or device. When you've taken the photo, you'll be able to review it to make sure it meets the rules.</p>
 
     {{ govukRadios({
         fieldset: {
@@ -30,7 +30,7 @@
         items: [
             {
                 value: "TAKE_A_PIC",
-                text: "Take a photo now using the laptop or device you’re on"
+                text: "Take a photo now using the laptop or device you're on"
             },
             {
                 value: "UPLOAD_A_PIC",


### PR DESCRIPTION
[ESUP-1879](https://dsdmoj.atlassian.net/browse/ESUP-1879)

Minor content changes to the 'Take a Photo' page in the set up online check ins journey.

<img width="1022" height="856" alt="image" src="https://github.com/user-attachments/assets/7b766161-66fe-4139-8072-467aac4817c4" />



[ESUP-1879]: https://dsdmoj.atlassian.net/browse/ESUP-1879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ