### PR TITLE
[ESUP-1885] - Add rationale for decision to sign PoP up to check ins

### DIFF
--- a/integration_tests/e2e/appointments/check-ins.cy.ts
+++ b/integration_tests/e2e/appointments/check-ins.cy.ts
@@ -188,7 +188,7 @@ context('Appointment check-ins', () => {
     cy.get('.govuk-error-message').should('contain', 'Select if any of these apply')
   })
 
-  it('should able to submit rationale details', () => {
+  it('should be able to submit rationale details', () => {
     loadPage()
     cy.get('[data-qa="online-checkin-btn"]').click()
     const eligibilityCheckPage = new EligibilityCheckPage()
@@ -251,7 +251,7 @@ context('Appointment check-ins', () => {
     })
   })
 
-  it('should able to submit check-in frequency details', () => {
+  it('should be able to submit check-in frequency details', () => {
     loadPage()
     cy.get('[data-qa="online-checkin-btn"]').click()
     const eligibilityCheckPage = new EligibilityCheckPage()
@@ -309,7 +309,7 @@ context('Appointment check-ins', () => {
     })
   })
 
-  it('should able to submit contact preference details', () => {
+  it('should be able to submit contact preference details', () => {
     loadPage()
     cy.get('[data-qa="online-checkin-btn"]').click()
     const eligibilityCheckPage = new EligibilityCheckPage()
@@ -345,7 +345,7 @@ context('Appointment check-ins', () => {
     photoOptionsPage.checkOnPage()
   })
 
-  it('should able to edit contact preference details', () => {
+  it('should be able to edit contact preference details', () => {
     loadPage()
     cy.get('[data-qa="online-checkin-btn"]').click()
     const eligibilityCheckPage = new EligibilityCheckPage()
@@ -376,7 +376,7 @@ context('Appointment check-ins', () => {
     contactPreferencePage.getElementData('updateBanner').should('contain.text', 'Contact details saved')
   })
 
-  it('Should able to choose photo options', () => {
+  it('should be able to choose photo options', () => {
     loadPage()
     cy.get('[data-qa="online-checkin-btn"]').click()
     const eligibilityCheckPage = new EligibilityCheckPage()
@@ -421,7 +421,7 @@ context('Appointment check-ins', () => {
     takeAPhotoOptionsPage.checkOnPage()
   })
 
-  it('Should able to upload a pic and show rules page', () => {
+  it('should be able to upload a pic and show rules page', () => {
     loadPage()
     cy.get('[data-qa="online-checkin-btn"]').click()
     const eligibilityCheckPage = new EligibilityCheckPage()
@@ -470,7 +470,7 @@ context('Appointment check-ins', () => {
     uploadAPhoto.checkOnPage()
   })
 
-  it('Should able to show cya and confirm page', () => {
+  it('should be able to show cya and confirm page', () => {
     loadPage()
     cy.get('[data-qa="online-checkin-btn"]').click()
     const eligibilityCheckPage = new EligibilityCheckPage()
@@ -523,7 +523,7 @@ context('Appointment check-ins', () => {
     checkinConfirmationPage.checkOnPage()
   })
 
-  it('Should able to take a photo and show cya and confirm page', () => {
+  it('should be able to take a photo and show cya and confirm page', () => {
     loadPage()
     cy.get('[data-qa="online-checkin-btn"]').click()
     const eligibilityCheckPage = new EligibilityCheckPage()
@@ -575,7 +575,7 @@ context('Appointment check-ins', () => {
     checkinConfirmationPage.checkOnPage()
   })
 
-  it('Should able to change options from cya', () => {
+  it('should be able to change options from cya', () => {
     loadPage()
     cy.get('[data-qa="online-checkin-btn"]').click()
     const eligibilityCheckPage = new EligibilityCheckPage()
@@ -775,7 +775,7 @@ context('check-ins error scenario ', () => {
     errorPage.checkPageTitle('Sorry, there is a problem with the service')
   })
 
-  it('Should able to show error message when same phone / email already registered', () => {
+  it('should be able to show error message when same phone / email already registered', () => {
     loadPage()
     cy.task('stubOffenderSetup422Response')
     cy.get('[data-qa="online-checkin-btn"]').click()
@@ -833,7 +833,7 @@ context('check-ins error scenario ', () => {
       )
   })
 
-  it('Should able to show check ins registration error message', () => {
+  it('should be able to show check ins registration error message', () => {
     loadPage()
     cy.task('stubOffenderSetup500Response')
     cy.get('[data-qa="online-checkin-btn"]').click()
@@ -886,7 +886,7 @@ context('check-ins error scenario ', () => {
     checkYourAnswersPage.getErrorText().should('contain.text', 'An error occurred during registration')
   })
 
-  it('Should able to show error page, when checkin registration fails', () => {
+  it('should be able to show error page, when checkin registration fails', () => {
     loadPage()
 
     cy.task('stubOffenderSetupComplete500Response')
@@ -1036,7 +1036,7 @@ context('check-ins overview and manage pages', () => {
     manageCheckins.getImage().should('have.attr', 'alt', 'Image of Alton Berge')
   })
 
-  it('should able to visit contact details page', () => {
+  it('should be able to visit contact details page', () => {
     cy.task('resetMocks')
     cy.visit(`/case/X778160`)
     const overviewPage = new OverviewPage()
@@ -1074,7 +1074,7 @@ context('check-ins overview and manage pages', () => {
     manageContact.checkOnPage()
   })
 
-  it('should able to vist change settings page', () => {
+  it('should be able to vist change settings page', () => {
     cy.task('resetMocks')
     cy.visit(`/case/X778160/appointments/check-in/manage/3fa85f64-5717-4562-b3fc-2c963f66afa7`)
     const manageCheckins = new ManageCheckins()
@@ -1099,7 +1099,7 @@ context('check-ins overview and manage pages', () => {
     appointmentsPage.checkOnPage()
   })
 
-  it('should able to stop check in', () => {
+  it('should be able to stop check in', () => {
     cy.task('resetMocks')
     cy.visit(`/case/X778160/appointments/check-in/manage/3fa85f64-5717-4562-b3fc-2c963f66afa7`)
     const manageCheckins = new ManageCheckins()
@@ -1117,7 +1117,7 @@ context('check-ins overview and manage pages', () => {
     manageCheckins.checkOnPage()
   })
 
-  it('should able to stop and restart online check ins', () => {
+  it('should be able to stop and restart online check ins', () => {
     cy.task('resetMocks')
     cy.visit(`/case/X778160/appointments/check-in/manage/3fa85f64-5717-4562-b3fc-2c963f66afa7/restart-checkin`)
 

--- a/integration_tests/e2e/appointments/check-ins.cy.ts
+++ b/integration_tests/e2e/appointments/check-ins.cy.ts
@@ -35,6 +35,7 @@ import PreviewSupportPage from '../../pages/check-ins/questions/preview/support'
 import EditQuestionPage from '../../pages/check-ins/questions/edit-question'
 import ListQuestionsPage from '../../pages/check-ins/questions/list-questions'
 import EligibilitySPOApprovalPage from '../../pages/check-ins/eligibility-spo-approval'
+import RationalePage from '../../pages/check-ins/rationale'
 
 const loadPage = () => {
   cy.task('resetMocks')
@@ -77,10 +78,7 @@ context('Appointment check-ins', () => {
     checkPage.getSubmitBtn().click()
 
     const supplementaryPage = new EligibilitySupplementaryPage()
-    supplementaryPage.getSubmitBtn().click()
-
-    const dateFrequencyPage = new DateFrequencyPage()
-    dateFrequencyPage.checkOnPage()
+    supplementaryPage.checkOnPage()
   })
 
   it('should navigate to supplementary eligibility page when more than one eligible option is selected', () => {
@@ -94,10 +92,7 @@ context('Appointment check-ins', () => {
     checkPage.getSubmitBtn().click()
 
     const supplementaryPage = new EligibilitySupplementaryPage()
-    supplementaryPage.getSubmitBtn().click()
-
-    const dateFrequencyPage = new DateFrequencyPage()
-    dateFrequencyPage.checkOnPage()
+    supplementaryPage.checkOnPage()
   })
 
   it('should navigate to full eligibility choice when "None of these apply" is selected', () => {
@@ -126,7 +121,7 @@ context('Appointment check-ins', () => {
     spoApprovalPage.checkOnPage()
   })
 
-  it('should navigate to date frequency when SPO approval checkbox is checked', () => {
+  it('should navigate to rationale page when SPO approval checkbox is checked', () => {
     loadPage()
     cy.get('[data-qa="online-checkin-btn"]').click()
 
@@ -141,10 +136,13 @@ context('Appointment check-ins', () => {
     const spoApprovalPage = new EligibilitySPOApprovalPage()
     spoApprovalPage.checkOnPage()
     spoApprovalPage.getCheckbox()
-    spoApprovalPage.getSubmitBtn()
+    spoApprovalPage.getCheckbox().check()
+    spoApprovalPage.getSubmitBtn().click()
+    const rationalePage = new RationalePage()
+    rationalePage.checkOnPage()
   })
 
-  it('should navigate to date frequency when "As well as existing face-to-face contact" radio is selected', () => {
+  it('should navigate to rationale page when "As well as existing face-to-face contact" radio is selected', () => {
     loadPage()
     cy.get('[data-qa="online-checkin-btn"]').click()
 
@@ -156,8 +154,8 @@ context('Appointment check-ins', () => {
     fullPage.getSupplementaryRadio().check()
     fullPage.getSubmitBtn().click()
 
-    const dateFrequencyPage = new DateFrequencyPage()
-    dateFrequencyPage.checkOnPage()
+    const rationalePage = new RationalePage()
+    rationalePage.checkOnPage()
   })
 
   it('should navigate to denied page when option 10 (Intensive Supervision Court pilot case) is selected', () => {
@@ -190,6 +188,37 @@ context('Appointment check-ins', () => {
     cy.get('.govuk-error-message').should('contain', 'Select if any of these apply')
   })
 
+  it('should able to submit rationale details', () => {
+    loadPage()
+    cy.get('[data-qa="online-checkin-btn"]').click()
+    const eligibilityCheckPage = new EligibilityCheckPage()
+    eligibilityCheckPage.getOptionOne().click()
+    eligibilityCheckPage.getSubmitBtn().click()
+    const eligibilitySupplementaryPage = new EligibilitySupplementaryPage()
+    eligibilitySupplementaryPage.checkOnPage()
+    eligibilitySupplementaryPage.getSubmitBtn().click()
+    const rationalePage = new RationalePage()
+    rationalePage.rationaleNotes().find('textarea').type('Low risk of reoffending')
+    rationalePage.getSubmitBtn().click()
+    const dateFrequencyPage = new DateFrequencyPage()
+    dateFrequencyPage.checkOnPage()
+  })
+
+  it('rationale page should fail with validation errors', () => {
+    loadPage()
+    cy.get('[data-qa="online-checkin-btn"]').click()
+    const eligibilityCheckPage = new EligibilityCheckPage()
+    eligibilityCheckPage.getOptionOne().click()
+    eligibilityCheckPage.getSubmitBtn().click()
+    const eligibilitySupplementaryPage = new EligibilitySupplementaryPage()
+    eligibilitySupplementaryPage.checkOnPage()
+    eligibilitySupplementaryPage.getSubmitBtn().click()
+    const rationalePage = new RationalePage()
+
+    rationalePage.getSubmitBtn().click()
+    rationalePage.getErrorSummaryBox().should('be.visible')
+  })
+
   it('check-in frequency page should fail with validation errors', () => {
     loadPage()
     cy.get('[data-qa="online-checkin-btn"]').click()
@@ -199,6 +228,9 @@ context('Appointment check-ins', () => {
     const eligibilitySupplementaryPage = new EligibilitySupplementaryPage()
     eligibilitySupplementaryPage.checkOnPage()
     eligibilitySupplementaryPage.getSubmitBtn().click()
+    const rationalePage = new RationalePage()
+    rationalePage.rationaleNotes().find('textarea').type('Low risk of reoffending')
+    rationalePage.getSubmitBtn().click()
     const dateFrequencyPage = new DateFrequencyPage()
     dateFrequencyPage.checkOnPage()
     dateFrequencyPage.getSubmitBtn().click()
@@ -228,6 +260,9 @@ context('Appointment check-ins', () => {
     const eligibilitySupplementaryPage = new EligibilitySupplementaryPage()
     eligibilitySupplementaryPage.checkOnPage()
     eligibilitySupplementaryPage.getSubmitBtn().click()
+    const rationalePage = new RationalePage()
+    rationalePage.rationaleNotes().find('textarea').type('Low risk of reoffending')
+    rationalePage.getSubmitBtn().click()
     const dateFrequencyPage = new DateFrequencyPage()
     dateFrequencyPage.checkOnPage()
     const now = DateTime.now()
@@ -251,6 +286,9 @@ context('Appointment check-ins', () => {
     const eligibilitySupplementaryPage = new EligibilitySupplementaryPage()
     eligibilitySupplementaryPage.checkOnPage()
     eligibilitySupplementaryPage.getSubmitBtn().click()
+    const rationalePage = new RationalePage()
+    rationalePage.rationaleNotes().find('textarea').type('Low risk of reoffending')
+    rationalePage.getSubmitBtn().click()
     const dateFrequencyPage = new DateFrequencyPage()
     dateFrequencyPage.checkOnPage()
     const now = DateTime.now()
@@ -280,6 +318,9 @@ context('Appointment check-ins', () => {
     const eligibilitySupplementaryPage = new EligibilitySupplementaryPage()
     eligibilitySupplementaryPage.checkOnPage()
     eligibilitySupplementaryPage.getSubmitBtn().click()
+    const rationalePage = new RationalePage()
+    rationalePage.rationaleNotes().find('textarea').type('Low risk of reoffending')
+    rationalePage.getSubmitBtn().click()
     const dateFrequencyPage = new DateFrequencyPage()
     dateFrequencyPage.checkOnPage()
     const now = DateTime.now()
@@ -313,6 +354,9 @@ context('Appointment check-ins', () => {
     const eligibilitySupplementaryPage = new EligibilitySupplementaryPage()
     eligibilitySupplementaryPage.checkOnPage()
     eligibilitySupplementaryPage.getSubmitBtn().click()
+    const rationalePage = new RationalePage()
+    rationalePage.rationaleNotes().find('textarea').type('Low risk of reoffending')
+    rationalePage.getSubmitBtn().click()
     const dateFrequencyPage = new DateFrequencyPage()
     dateFrequencyPage.checkOnPage()
     const now = DateTime.now()
@@ -341,6 +385,9 @@ context('Appointment check-ins', () => {
     const eligibilitySupplementaryPage = new EligibilitySupplementaryPage()
     eligibilitySupplementaryPage.checkOnPage()
     eligibilitySupplementaryPage.getSubmitBtn().click()
+    const rationalePage = new RationalePage()
+    rationalePage.rationaleNotes().find('textarea').type('Low risk of reoffending')
+    rationalePage.getSubmitBtn().click()
     const dateFrequencyPage = new DateFrequencyPage()
     dateFrequencyPage.checkOnPage()
     const now = DateTime.now()
@@ -383,6 +430,9 @@ context('Appointment check-ins', () => {
     const eligibilitySupplementaryPage = new EligibilitySupplementaryPage()
     eligibilitySupplementaryPage.checkOnPage()
     eligibilitySupplementaryPage.getSubmitBtn().click()
+    const rationalePage = new RationalePage()
+    rationalePage.rationaleNotes().find('textarea').type('Low risk of reoffending')
+    rationalePage.getSubmitBtn().click()
     const dateFrequencyPage = new DateFrequencyPage()
     dateFrequencyPage.checkOnPage()
     const now = DateTime.now()
@@ -429,6 +479,9 @@ context('Appointment check-ins', () => {
     const eligibilitySupplementaryPage = new EligibilitySupplementaryPage()
     eligibilitySupplementaryPage.checkOnPage()
     eligibilitySupplementaryPage.getSubmitBtn().click()
+    const rationalePage = new RationalePage()
+    rationalePage.rationaleNotes().find('textarea').type('Low risk of reoffending')
+    rationalePage.getSubmitBtn().click()
     const dateFrequencyPage = new DateFrequencyPage()
     dateFrequencyPage.checkOnPage()
     const now = DateTime.now()
@@ -479,6 +532,9 @@ context('Appointment check-ins', () => {
     const eligibilitySupplementaryPage = new EligibilitySupplementaryPage()
     eligibilitySupplementaryPage.checkOnPage()
     eligibilitySupplementaryPage.getSubmitBtn().click()
+    const rationalePage = new RationalePage()
+    rationalePage.rationaleNotes().find('textarea').type('Low risk of reoffending')
+    rationalePage.getSubmitBtn().click()
     const dateFrequencyPage = new DateFrequencyPage()
     dateFrequencyPage.checkOnPage()
     const now = DateTime.now()
@@ -528,6 +584,9 @@ context('Appointment check-ins', () => {
     const eligibilitySupplementaryPage = new EligibilitySupplementaryPage()
     eligibilitySupplementaryPage.checkOnPage()
     eligibilitySupplementaryPage.getSubmitBtn().click()
+    const rationalePage = new RationalePage()
+    rationalePage.rationaleNotes().find('textarea').type('Low risk of reoffending')
+    rationalePage.getSubmitBtn().click()
     const dateFrequencyPage = new DateFrequencyPage()
     dateFrequencyPage.checkOnPage()
     const now = DateTime.now()
@@ -564,21 +623,37 @@ context('Appointment check-ins', () => {
     const checkYourAnswersPage = new CheckYourAnswersPage()
     checkYourAnswersPage.checkOnPage()
 
+    // Rationale change
+    checkYourAnswersPage
+      .getSummaryListRow(1)
+      .find('.govuk-summary-list__value')
+      .should('contain.text', 'Low risk of reoffending')
+    checkYourAnswersPage.getElementData('rationaleAction').click()
+    rationalePage.checkOnPage()
+    rationalePage.rationaleNotes().find('textarea').clear()
+    rationalePage.rationaleNotes().find('textarea').type('Hard for them to travel to the office')
+    rationalePage.getSubmitBtn().click()
+    checkYourAnswersPage.checkOnPage()
+    checkYourAnswersPage
+      .getSummaryListRow(1)
+      .find('.govuk-summary-list__value')
+      .should('contain.text', 'Hard for them to travel to the office')
+
     // Date change
     checkYourAnswersPage.getElementData('dateAction').click()
     dateFrequencyPage.checkOnPage()
     dateFrequencyPage.getSubmitBtn().click()
     checkYourAnswersPage.checkOnPage()
-    checkYourAnswersPage.getSummaryListRow(2).find('.govuk-summary-list__value').should('contain.text', 'Every week')
+    checkYourAnswersPage.getSummaryListRow(3).find('.govuk-summary-list__value').should('contain.text', 'Every week')
     checkYourAnswersPage.getElementData('intervalAction').click()
     dateFrequencyPage.checkOnPage()
     dateFrequencyPage.getFrequency().find('.govuk-radios__item').eq(2).find('.govuk-radios__input').click()
     dateFrequencyPage.getSubmitBtn().click()
     checkYourAnswersPage.checkOnPage()
-    checkYourAnswersPage.getSummaryListRow(2).find('.govuk-summary-list__value').should('contain.text', 'Every 4 weeks')
+    checkYourAnswersPage.getSummaryListRow(3).find('.govuk-summary-list__value').should('contain.text', 'Every 4 weeks')
 
     // Contact preference change
-    checkYourAnswersPage.getSummaryListRow(3).find('.govuk-summary-list__value').should('contain.text', 'Text message')
+    checkYourAnswersPage.getSummaryListRow(4).find('.govuk-summary-list__value').should('contain.text', 'Text message')
     checkYourAnswersPage.getElementData('preferredComsAction').click()
     contactPreferencePage.checkOnPage()
     contactPreferencePage
@@ -589,7 +664,7 @@ context('Appointment check-ins', () => {
       .click()
     contactPreferencePage.getSubmitBtn().click()
     checkYourAnswersPage.checkOnPage()
-    checkYourAnswersPage.getSummaryListRow(3).find('.govuk-summary-list__value').should('contain.text', 'Email')
+    checkYourAnswersPage.getSummaryListRow(4).find('.govuk-summary-list__value').should('contain.text', 'Email')
 
     // Mobile
     checkYourAnswersPage.getElementData('checkInMobileAction').click()
@@ -611,7 +686,7 @@ context('Appointment check-ins', () => {
 
     // photo options
     checkYourAnswersPage
-      .getSummaryListRow(6)
+      .getSummaryListRow(7)
       .find('.govuk-summary-list__value')
       .should('contain.text', 'Take a photo using this device')
     checkYourAnswersPage.getElementData('photoUploadOptionAction').click()
@@ -627,7 +702,7 @@ context('Appointment check-ins', () => {
     photoRules.getSubmitBtn().click()
     checkYourAnswersPage.checkOnPage()
     checkYourAnswersPage
-      .getSummaryListRow(6)
+      .getSummaryListRow(7)
       .find('.govuk-summary-list__value')
       .should('contain.text', 'Upload a photo')
   })
@@ -644,6 +719,9 @@ context('check-ins error scenario ', () => {
     const eligibilitySupplementaryPage = new EligibilitySupplementaryPage()
     eligibilitySupplementaryPage.checkOnPage()
     eligibilitySupplementaryPage.getSubmitBtn().click()
+    const rationalePage = new RationalePage()
+    rationalePage.rationaleNotes().find('textarea').type('Low risk of reoffending')
+    rationalePage.getSubmitBtn().click()
     const dateFrequencyPage = new DateFrequencyPage()
     dateFrequencyPage.checkOnPage()
     const now = DateTime.now()
@@ -674,6 +752,9 @@ context('check-ins error scenario ', () => {
     const eligibilitySupplementaryPage = new EligibilitySupplementaryPage()
     eligibilitySupplementaryPage.checkOnPage()
     eligibilitySupplementaryPage.getSubmitBtn().click()
+    const rationalePage = new RationalePage()
+    rationalePage.rationaleNotes().find('textarea').type('Low risk of reoffending')
+    rationalePage.getSubmitBtn().click()
     const dateFrequencyPage = new DateFrequencyPage()
     dateFrequencyPage.checkOnPage()
     const now = DateTime.now()
@@ -704,6 +785,9 @@ context('check-ins error scenario ', () => {
     const eligibilitySupplementaryPage = new EligibilitySupplementaryPage()
     eligibilitySupplementaryPage.checkOnPage()
     eligibilitySupplementaryPage.getSubmitBtn().click()
+    const rationalePage = new RationalePage()
+    rationalePage.rationaleNotes().find('textarea').type('Low risk of reoffending')
+    rationalePage.getSubmitBtn().click()
     const dateFrequencyPage = new DateFrequencyPage()
     dateFrequencyPage.checkOnPage()
     const now = DateTime.now()
@@ -759,6 +843,9 @@ context('check-ins error scenario ', () => {
     const eligibilitySupplementaryPage = new EligibilitySupplementaryPage()
     eligibilitySupplementaryPage.checkOnPage()
     eligibilitySupplementaryPage.getSubmitBtn().click()
+    const rationalePage = new RationalePage()
+    rationalePage.rationaleNotes().find('textarea').type('Low risk of reoffending')
+    rationalePage.getSubmitBtn().click()
     const dateFrequencyPage = new DateFrequencyPage()
     dateFrequencyPage.checkOnPage()
     const now = DateTime.now()
@@ -811,6 +898,9 @@ context('check-ins error scenario ', () => {
     const eligibilitySupplementaryPage = new EligibilitySupplementaryPage()
     eligibilitySupplementaryPage.checkOnPage()
     eligibilitySupplementaryPage.getSubmitBtn().click()
+    const rationalePage = new RationalePage()
+    rationalePage.rationaleNotes().find('textarea').type('Low risk of reoffending')
+    rationalePage.getSubmitBtn().click()
     const dateFrequencyPage = new DateFrequencyPage()
 
     dateFrequencyPage.checkOnPage()

--- a/integration_tests/e2e/appointments/check-ins.cy.ts
+++ b/integration_tests/e2e/appointments/check-ins.cy.ts
@@ -135,7 +135,6 @@ context('Appointment check-ins', () => {
 
     const spoApprovalPage = new EligibilitySPOApprovalPage()
     spoApprovalPage.checkOnPage()
-    spoApprovalPage.getCheckbox()
     spoApprovalPage.getCheckbox().check()
     spoApprovalPage.getSubmitBtn().click()
     const rationalePage = new RationalePage()

--- a/integration_tests/pages/check-ins/rationale.ts
+++ b/integration_tests/pages/check-ins/rationale.ts
@@ -8,4 +8,8 @@ export default class RationalePage extends Page {
   rationaleNotes = () => cy.get('[data-qa="rationale-for-check-ins"]')
 
   getSubmitBtn = (): PageElement => cy.get('[data-qa="submit-btn"]')
+
+  checkOnPage(): void {
+    cy.contains('label', 'suitable to use online check ins?').should('be.visible')
+  }
 }

--- a/integration_tests/pages/check-ins/rationale.ts
+++ b/integration_tests/pages/check-ins/rationale.ts
@@ -1,0 +1,11 @@
+import Page, { PageElement } from '../page'
+
+export default class RationalePage extends Page {
+  constructor() {
+    super('suitable to use online check ins?')
+  }
+
+  rationaleNotes = () => cy.get('[data-qa="rationale-for-check-ins"]')
+
+  getSubmitBtn = (): PageElement => cy.get('[data-qa="submit-btn"]')
+}

--- a/server/controllers/check-ins.test.ts
+++ b/server/controllers/check-ins.test.ts
@@ -734,6 +734,52 @@ describe('checkInsController', () => {
         }),
       )
     })
+
+    it('uses SPO approval as date-frequency backLink when rationale is off and replacing F2F', async () => {
+      mockIsValidCrn.mockReturnValue(true)
+      mockIsValidUUID.mockReturnValue(true)
+
+      const req = baseReq()
+      res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: false }
+
+      req.session.data = {
+        esupervision: {
+          [crn]: {
+            [uuid]: {
+              checkins: {
+                eligibilityChoice: 'REPLACE_F2F',
+              },
+            },
+          },
+        },
+      }
+
+      await controllers.checkIns.getDateFrequencyPage(hmppsAuthClient)(req, res)
+
+      expect(renderSpy).toHaveBeenCalledWith(
+        'pages/check-in/date-frequency.njk',
+        expect.objectContaining({
+          backLink: `/case/${crn}/appointments/${uuid}/check-in/spo-approval`,
+        }),
+      )
+    })
+
+    it('uses supplementary eligibility as date-frequency backLink when rationale is off by default', async () => {
+      mockIsValidCrn.mockReturnValue(true)
+      mockIsValidUUID.mockReturnValue(true)
+
+      const req = baseReq()
+      res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: false }
+
+      await controllers.checkIns.getDateFrequencyPage(hmppsAuthClient)(req, res)
+
+      expect(renderSpy).toHaveBeenCalledWith(
+        'pages/check-in/date-frequency.njk',
+        expect.objectContaining({
+          backLink: `/case/${crn}/appointments/${uuid}/check-in/supplementary-eligibility`,
+        }),
+      )
+    })
   })
 
   describe('postDateFrequencyPage', () => {

--- a/server/controllers/check-ins.test.ts
+++ b/server/controllers/check-ins.test.ts
@@ -599,32 +599,22 @@ describe('checkInsController', () => {
       })
     })
 
-    it('uses full eligibility as rationale backLink when eligibility-none was selected', async () => {
+    it('uses summary as rationale backLink when cya=true', async () => {
       mockIsValidCrn.mockReturnValue(true)
       mockIsValidUUID.mockReturnValue(true)
 
       const req = baseReq()
+      req.query = { cya: 'true' }
       res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
-
-      req.session.data = {
-        esupervision: {
-          [crn]: {
-            [uuid]: {
-              checkins: {
-                eligibility: ['eligibility-none'],
-              },
-            },
-          },
-        },
-      }
 
       await controllers.checkIns.getRationalePage(hmppsAuthClient)(req, res)
 
-      expect(renderSpy).toHaveBeenCalledWith('pages/check-in/rationale.njk', {
-        crn,
-        id: uuid,
-        backLink: `/case/${crn}/appointments/${uuid}/check-in/full-eligibility`,
-      })
+      expect(renderSpy).toHaveBeenCalledWith(
+        'pages/check-in/rationale.njk',
+        expect.objectContaining({
+          backLink: `/case/${crn}/appointments/${uuid}/check-in/checkin-summary`,
+        }),
+      )
     })
   })
 

--- a/server/controllers/check-ins.test.ts
+++ b/server/controllers/check-ins.test.ts
@@ -210,6 +210,7 @@ describe('checkInsController', () => {
 
         const req = baseReq()
         const { id } = req.params as Record<string, string>
+        res.locals.flags = { enableEsupervisionRationale: true }
         await controllers.checkIns.getEligibilityDeniedPage(hmppsAuthClient)(req, res)
 
         expect(renderSpy).toHaveBeenCalledWith('pages/check-in/eligibility-denied.njk', {
@@ -224,6 +225,7 @@ describe('checkInsController', () => {
       it('returns 404 when CRN is invalid', async () => {
         mockIsValidCrn.mockReturnValue(false)
         mockIsValidUUID.mockReturnValue(true)
+        res.locals.flags = { enableEsupervisionRationale: true }
 
         const req = baseReq()
         await controllers.checkIns.getEligibilityDeniedPage(hmppsAuthClient)(req, res)
@@ -240,6 +242,7 @@ describe('checkInsController', () => {
 
         const req = baseReq()
         const { id } = req.params as Record<string, string>
+        res.locals.flags = { enableEsupervisionRationale: true }
         await controllers.checkIns.getFullEligibilityPage(hmppsAuthClient)(req, res)
 
         expect(renderSpy).toHaveBeenCalledWith('pages/check-in/eligibility-full.njk', {
@@ -256,6 +259,7 @@ describe('checkInsController', () => {
         mockIsValidUUID.mockReturnValue(true)
 
         const req = baseReq()
+        res.locals.flags = { enableEsupervisionRationale: true }
         await controllers.checkIns.getFullEligibilityPage(hmppsAuthClient)(req, res)
 
         expect(mockRenderError).toHaveBeenCalledWith(404)
@@ -295,14 +299,14 @@ describe('checkInsController', () => {
     })
 
     describe('postSPOApprovalPage', () => {
-      it('redirects to date frequency when CRN and id are valid', async () => {
+      it('redirects to rationale page when CRN and id are valid', async () => {
         mockIsValidCrn.mockReturnValue(true)
         mockIsValidUUID.mockReturnValue(true)
 
         const req = baseReq()
         await controllers.checkIns.postSPOApprovalPage(hmppsAuthClient)(req, res)
 
-        expect(redirectSpy).toHaveBeenCalledWith(`/case/${crn}/appointments/${uuid}/check-in/date-frequency`)
+        expect(redirectSpy).toHaveBeenCalledWith(`/case/${crn}/appointments/${uuid}/check-in/rationale`)
       })
 
       it('returns 404 when CRN is invalid', async () => {
@@ -403,7 +407,7 @@ describe('checkInsController', () => {
     })
 
     describe('Full and Supplementary Results', () => {
-      it('postFullEligibilityPage saves data and redirects to date-frequency', async () => {
+      it('postFullEligibilityPage saves data and redirects to rationale page', async () => {
         mockIsValidCrn.mockReturnValue(true)
         mockIsValidUUID.mockReturnValue(true)
 
@@ -413,10 +417,10 @@ describe('checkInsController', () => {
         await controllers.checkIns.postFullEligibilityPage(hmppsAuthClient)(req, res)
 
         expect(mockSetDataValue).toHaveBeenCalledWith(req.session.data, ['esupervision', crn, id, 'checkins', 'id'], id)
-        expect(redirectSpy).toHaveBeenCalledWith(`/case/${crn}/appointments/${id}/check-in/date-frequency`)
+        expect(redirectSpy).toHaveBeenCalledWith(`/case/${crn}/appointments/${id}/check-in/rationale`)
       })
 
-      it('postSupplementaryEligibilityPage saves data and redirects to date-frequency', async () => {
+      it('postSupplementaryEligibilityPage saves data and redirects to rationale page', async () => {
         mockIsValidCrn.mockReturnValue(true)
         mockIsValidUUID.mockReturnValue(true)
 
@@ -426,7 +430,7 @@ describe('checkInsController', () => {
         await controllers.checkIns.postSupplementaryEligibilityPage(hmppsAuthClient)(req, res)
 
         expect(mockSetDataValue).toHaveBeenCalledWith(req.session.data, ['esupervision', crn, id, 'checkins', 'id'], id)
-        expect(redirectSpy).toHaveBeenCalledWith(`/case/${crn}/appointments/${id}/check-in/date-frequency`)
+        expect(redirectSpy).toHaveBeenCalledWith(`/case/${crn}/appointments/${id}/check-in/rationale`)
       })
     })
 
@@ -444,6 +448,70 @@ describe('checkInsController', () => {
     })
   })
 
+  describe('getRationalePage', () => {
+    it('renders date frequency page when CRN and id are valid', async () => {
+      mockIsValidCrn.mockReturnValue(true)
+      mockIsValidUUID.mockReturnValue(true)
+
+      const req = baseReq()
+      const { id } = req.params as Record<string, string>
+      await controllers.checkIns.getRationalePage(hmppsAuthClient)(req, res)
+
+      expect(renderSpy).toHaveBeenCalledWith('pages/check-in/rationale.njk', {
+        crn,
+        id,
+        backLink: `/case/${crn}/appointments/${uuid}/check-in/supplementary-eligibility`,
+      })
+      expect(mockRenderError).not.toHaveBeenCalled()
+      checkSendAuditMessage(res, 'VIEW_MAS_RATIONALE_TO_USE_CHECK_INS', crn, SubjectType.CRN)
+    })
+
+    it('returns 404 when CRN is invalid', async () => {
+      mockIsValidCrn.mockReturnValue(false)
+      mockIsValidUUID.mockReturnValue(true)
+
+      const req = baseReq()
+      await controllers.checkIns.getRationalePage(hmppsAuthClient)(req, res)
+
+      expect(mockRenderError).toHaveBeenCalledWith(404)
+      expect(mockMiddlewareFn).toHaveBeenCalledWith(req, res)
+    })
+  })
+
+  describe('postRationalePage', () => {
+    it('redirects to date frequency page when CRN and id are valid', async () => {
+      mockIsValidCrn.mockReturnValue(true)
+      mockIsValidUUID.mockReturnValue(true)
+
+      const req = baseReq()
+      await controllers.checkIns.postRationalePage(hmppsAuthClient)(req, res)
+
+      expect(redirectSpy).toHaveBeenCalledWith(`/case/${crn}/appointments/${uuid}/check-in/date-frequency`)
+    })
+
+    it('returns 404 when CRN is invalid', async () => {
+      mockIsValidCrn.mockReturnValue(false)
+      mockIsValidUUID.mockReturnValue(true)
+
+      const req = baseReq()
+      await controllers.checkIns.postRationalePage(hmppsAuthClient)(req, res)
+
+      expect(mockRenderError).toHaveBeenCalledWith(404)
+      expect(mockMiddlewareFn).toHaveBeenCalledWith(req, res)
+    })
+
+    it('returns 404 when id is not a valid UUID', async () => {
+      mockIsValidCrn.mockReturnValue(true)
+      mockIsValidUUID.mockReturnValue(false)
+
+      const req = baseReq()
+      await controllers.checkIns.postRationalePage(hmppsAuthClient)(req, res)
+
+      expect(mockRenderError).toHaveBeenCalledWith(404)
+      expect(mockMiddlewareFn).toHaveBeenCalledWith(req, res)
+    })
+  })
+
   describe('getDateFrequencyPage', () => {
     it('renders with min date using single-digit day format (d/M/yyyy)', async () => {
       jest.useFakeTimers()
@@ -453,6 +521,7 @@ describe('checkInsController', () => {
       mockIsValidUUID.mockReturnValue(true)
 
       const req = baseReq()
+      res.locals.flags = { enableEsupervisionRationale: true }
       await controllers.checkIns.getDateFrequencyPage(hmppsAuthClient)(req, res)
 
       expect(renderSpy).toHaveBeenCalledWith('pages/check-in/date-frequency.njk', {
@@ -460,7 +529,7 @@ describe('checkInsController', () => {
         id: uuid,
         checkInMinDate: '1/7/2025',
         cya,
-        backLink: `/case/${crn}/appointments/${uuid}/check-in/supplementary-eligibility`,
+        backLink: `/case/${crn}/appointments/${uuid}/check-in/rationale`,
       })
       checkSendAuditMessage(res, 'VIEW_MAS_SETUP_ONLINE_CHECK_INS', crn, SubjectType.CRN)
     })
@@ -473,6 +542,7 @@ describe('checkInsController', () => {
       mockIsValidUUID.mockReturnValue(true)
 
       const req = baseReq()
+      res.locals.flags = { enableEsupervisionRationale: true }
       await controllers.checkIns.getDateFrequencyPage(hmppsAuthClient)(req, res)
 
       expect(renderSpy).toHaveBeenCalledWith('pages/check-in/date-frequency.njk', {
@@ -480,7 +550,7 @@ describe('checkInsController', () => {
         id: uuid,
         checkInMinDate: '9/7/2025',
         cya,
-        backLink: `/case/${crn}/appointments/${uuid}/check-in/supplementary-eligibility`,
+        backLink: `/case/${crn}/appointments/${uuid}/check-in/rationale`,
       })
     })
 

--- a/server/controllers/check-ins.test.ts
+++ b/server/controllers/check-ins.test.ts
@@ -495,6 +495,7 @@ describe('checkInsController', () => {
         mockIsValidUUID.mockReturnValue(true)
 
         const req = baseReq()
+        res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
         const { id } = req.params as Record<string, string>
 
         await controllers.checkIns.postSupplementaryEligibilityPage(hmppsAuthClient)(req, res)

--- a/server/controllers/check-ins.test.ts
+++ b/server/controllers/check-ins.test.ts
@@ -210,7 +210,7 @@ describe('checkInsController', () => {
 
         const req = baseReq()
         const { id } = req.params as Record<string, string>
-        res.locals.flags = { enableEsupervisionRationale: true }
+        res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
         await controllers.checkIns.getEligibilityDeniedPage(hmppsAuthClient)(req, res)
 
         expect(renderSpy).toHaveBeenCalledWith('pages/check-in/eligibility-denied.njk', {
@@ -225,7 +225,7 @@ describe('checkInsController', () => {
       it('returns 404 when CRN is invalid', async () => {
         mockIsValidCrn.mockReturnValue(false)
         mockIsValidUUID.mockReturnValue(true)
-        res.locals.flags = { enableEsupervisionRationale: true }
+        res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
 
         const req = baseReq()
         await controllers.checkIns.getEligibilityDeniedPage(hmppsAuthClient)(req, res)
@@ -242,7 +242,7 @@ describe('checkInsController', () => {
 
         const req = baseReq()
         const { id } = req.params as Record<string, string>
-        res.locals.flags = { enableEsupervisionRationale: true }
+        res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
         await controllers.checkIns.getFullEligibilityPage(hmppsAuthClient)(req, res)
 
         expect(renderSpy).toHaveBeenCalledWith('pages/check-in/eligibility-full.njk', {
@@ -259,7 +259,7 @@ describe('checkInsController', () => {
         mockIsValidUUID.mockReturnValue(true)
 
         const req = baseReq()
-        res.locals.flags = { enableEsupervisionRationale: true }
+        res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
         await controllers.checkIns.getFullEligibilityPage(hmppsAuthClient)(req, res)
 
         expect(mockRenderError).toHaveBeenCalledWith(404)
@@ -273,6 +273,7 @@ describe('checkInsController', () => {
         mockIsValidUUID.mockReturnValue(true)
 
         const req = baseReq()
+        res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
         const { id } = req.params as Record<string, string>
         await controllers.checkIns.getSPOApprovalPage(hmppsAuthClient)(req, res)
 
@@ -291,10 +292,40 @@ describe('checkInsController', () => {
         mockIsValidUUID.mockReturnValue(true)
 
         const req = baseReq()
+        res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
         await controllers.checkIns.getSPOApprovalPage(hmppsAuthClient)(req, res)
 
         expect(mockRenderError).toHaveBeenCalledWith(404)
         expect(mockMiddlewareFn).toHaveBeenCalledWith(req, res)
+      })
+
+      it('sets isApproved true when SPO approval is selected', async () => {
+        mockIsValidCrn.mockReturnValue(true)
+        mockIsValidUUID.mockReturnValue(true)
+
+        res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
+
+        const req = baseReq()
+        req.session.data = {
+          esupervision: {
+            [crn]: {
+              [uuid]: {
+                checkins: {
+                  eligibilitySPOApproval: 'spo-approval',
+                },
+              },
+            },
+          },
+        }
+
+        await controllers.checkIns.getSPOApprovalPage(hmppsAuthClient)(req, res)
+
+        expect(renderSpy).toHaveBeenCalledWith('pages/check-in/spo-approval.njk', {
+          crn,
+          id: uuid,
+          back: req.query.back,
+          isApproved: true,
+        })
       })
     })
 
@@ -304,6 +335,7 @@ describe('checkInsController', () => {
         mockIsValidUUID.mockReturnValue(true)
 
         const req = baseReq()
+        res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
         await controllers.checkIns.postSPOApprovalPage(hmppsAuthClient)(req, res)
 
         expect(redirectSpy).toHaveBeenCalledWith(`/case/${crn}/appointments/${uuid}/check-in/rationale`)
@@ -314,6 +346,7 @@ describe('checkInsController', () => {
         mockIsValidUUID.mockReturnValue(true)
 
         const req = baseReq()
+        res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
         await controllers.checkIns.postSPOApprovalPage(hmppsAuthClient)(req, res)
 
         expect(mockRenderError).toHaveBeenCalledWith(404)
@@ -325,10 +358,23 @@ describe('checkInsController', () => {
         mockIsValidUUID.mockReturnValue(false)
 
         const req = baseReq()
+        res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
         await controllers.checkIns.postSPOApprovalPage(hmppsAuthClient)(req, res)
 
         expect(mockRenderError).toHaveBeenCalledWith(404)
         expect(mockMiddlewareFn).toHaveBeenCalledWith(req, res)
+      })
+
+      it('redirects SPO approval to date-frequency when rationale flag is off', async () => {
+        mockIsValidCrn.mockReturnValue(true)
+        mockIsValidUUID.mockReturnValue(true)
+
+        const req = baseReq()
+        res.locals.flags = { enableEsupervisionRationale: false }
+
+        await controllers.checkIns.postSPOApprovalPage(hmppsAuthClient)(req, res)
+
+        expect(redirectSpy).toHaveBeenCalledWith(`/case/${crn}/appointments/${uuid}/check-in/date-frequency`)
       })
     })
 
@@ -412,12 +458,36 @@ describe('checkInsController', () => {
         mockIsValidUUID.mockReturnValue(true)
 
         const req = baseReq()
+        res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
         const { id } = req.params as Record<string, string>
 
         await controllers.checkIns.postFullEligibilityPage(hmppsAuthClient)(req, res)
 
         expect(mockSetDataValue).toHaveBeenCalledWith(req.session.data, ['esupervision', crn, id, 'checkins', 'id'], id)
         expect(redirectSpy).toHaveBeenCalledWith(`/case/${crn}/appointments/${id}/check-in/rationale`)
+      })
+
+      it('redirects full eligibility to SPO approval when replacing F2F', async () => {
+        mockIsValidCrn.mockReturnValue(true)
+        mockIsValidUUID.mockReturnValue(true)
+        res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
+
+        const req = baseReq()
+        req.session.data = {
+          esupervision: {
+            [crn]: {
+              [uuid]: {
+                checkins: {
+                  eligibilityChoice: 'REPLACE_F2F',
+                },
+              },
+            },
+          },
+        }
+
+        await controllers.checkIns.postFullEligibilityPage(hmppsAuthClient)(req, res)
+
+        expect(redirectSpy).toHaveBeenCalledWith(`/case/${crn}/appointments/${uuid}/check-in/spo-approval`)
       })
 
       it('postSupplementaryEligibilityPage saves data and redirects to rationale page', async () => {
@@ -431,6 +501,18 @@ describe('checkInsController', () => {
 
         expect(mockSetDataValue).toHaveBeenCalledWith(req.session.data, ['esupervision', crn, id, 'checkins', 'id'], id)
         expect(redirectSpy).toHaveBeenCalledWith(`/case/${crn}/appointments/${id}/check-in/rationale`)
+      })
+
+      it('redirects supplementary eligibility to date-frequency when rationale flag is off', async () => {
+        mockIsValidCrn.mockReturnValue(true)
+        mockIsValidUUID.mockReturnValue(true)
+
+        const req = baseReq()
+        res.locals.flags = { enableEsupervisionRationale: false }
+
+        await controllers.checkIns.postSupplementaryEligibilityPage(hmppsAuthClient)(req, res)
+
+        expect(redirectSpy).toHaveBeenCalledWith(`/case/${crn}/appointments/${uuid}/check-in/date-frequency`)
       })
     })
 
@@ -449,11 +531,13 @@ describe('checkInsController', () => {
   })
 
   describe('getRationalePage', () => {
-    it('renders date frequency page when CRN and id are valid', async () => {
+    it('renders rationale page when CRN and id are valid', async () => {
       mockIsValidCrn.mockReturnValue(true)
       mockIsValidUUID.mockReturnValue(true)
 
       const req = baseReq()
+      res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
+
       const { id } = req.params as Record<string, string>
       await controllers.checkIns.getRationalePage(hmppsAuthClient)(req, res)
 
@@ -475,6 +559,72 @@ describe('checkInsController', () => {
 
       expect(mockRenderError).toHaveBeenCalledWith(404)
       expect(mockMiddlewareFn).toHaveBeenCalledWith(req, res)
+    })
+
+    it('redirects rationale page to case overview when rationale flag is off', async () => {
+      const req = baseReq()
+
+      res.locals.flags = { enableEsupervisionRationale: false }
+
+      await controllers.checkIns.getRationalePage(hmppsAuthClient)(req, res)
+
+      expect(redirectSpy).toHaveBeenCalledWith(`/case/${crn}`)
+    })
+
+    it('uses SPO approval as rationale backLink for REPLACE_F2F', async () => {
+      mockIsValidCrn.mockReturnValue(true)
+      mockIsValidUUID.mockReturnValue(true)
+
+      const req = baseReq()
+      res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
+
+      req.session.data = {
+        esupervision: {
+          [crn]: {
+            [uuid]: {
+              checkins: {
+                eligibilityChoice: 'REPLACE_F2F',
+              },
+            },
+          },
+        },
+      }
+
+      await controllers.checkIns.getRationalePage(hmppsAuthClient)(req, res)
+
+      expect(renderSpy).toHaveBeenCalledWith('pages/check-in/rationale.njk', {
+        crn,
+        id: uuid,
+        backLink: `/case/${crn}/appointments/${uuid}/check-in/spo-approval`,
+      })
+    })
+
+    it('uses full eligibility as rationale backLink when eligibility-none was selected', async () => {
+      mockIsValidCrn.mockReturnValue(true)
+      mockIsValidUUID.mockReturnValue(true)
+
+      const req = baseReq()
+      res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
+
+      req.session.data = {
+        esupervision: {
+          [crn]: {
+            [uuid]: {
+              checkins: {
+                eligibility: ['eligibility-none'],
+              },
+            },
+          },
+        },
+      }
+
+      await controllers.checkIns.getRationalePage(hmppsAuthClient)(req, res)
+
+      expect(renderSpy).toHaveBeenCalledWith('pages/check-in/rationale.njk', {
+        crn,
+        id: uuid,
+        backLink: `/case/${crn}/appointments/${uuid}/check-in/full-eligibility`,
+      })
     })
   })
 
@@ -521,7 +671,7 @@ describe('checkInsController', () => {
       mockIsValidUUID.mockReturnValue(true)
 
       const req = baseReq()
-      res.locals.flags = { enableEsupervisionRationale: true }
+      res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
       await controllers.checkIns.getDateFrequencyPage(hmppsAuthClient)(req, res)
 
       expect(renderSpy).toHaveBeenCalledWith('pages/check-in/date-frequency.njk', {
@@ -542,7 +692,7 @@ describe('checkInsController', () => {
       mockIsValidUUID.mockReturnValue(true)
 
       const req = baseReq()
-      res.locals.flags = { enableEsupervisionRationale: true }
+      res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
       await controllers.checkIns.getDateFrequencyPage(hmppsAuthClient)(req, res)
 
       expect(renderSpy).toHaveBeenCalledWith('pages/check-in/date-frequency.njk', {
@@ -574,6 +724,25 @@ describe('checkInsController', () => {
 
       expect(mockRenderError).toHaveBeenCalledWith(404)
       expect(mockMiddlewareFn).toHaveBeenCalledWith(req, res)
+    })
+
+    it('uses summary as date-frequency backLink when cya=true', async () => {
+      mockIsValidCrn.mockReturnValue(true)
+      mockIsValidUUID.mockReturnValue(true)
+
+      const req = baseReq()
+      req.query = { cya: 'true' }
+      res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
+
+      await controllers.checkIns.getDateFrequencyPage(hmppsAuthClient)(req, res)
+
+      expect(renderSpy).toHaveBeenCalledWith(
+        'pages/check-in/date-frequency.njk',
+        expect.objectContaining({
+          cya: true,
+          backLink: `/case/${crn}/appointments/${uuid}/check-in/checkin-summary`,
+        }),
+      )
     })
   })
 

--- a/server/controllers/check-ins.test.ts
+++ b/server/controllers/check-ins.test.ts
@@ -1260,6 +1260,7 @@ describe('checkInsController', () => {
               interval: 'WEEKLY',
               preferredComs: 'EMAIL',
               photoUploadOption: 'TAKE_A_PIC',
+              rationale: 'Unlikely to reoffend',
             },
           },
         },
@@ -1269,7 +1270,7 @@ describe('checkInsController', () => {
     it('renders summary with transformed userDetails when CRN and id are valid', async () => {
       mockIsValidCrn.mockReturnValue(true)
       mockIsValidUUID.mockReturnValue(true)
-
+      res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
       const req = httpMocks.createRequest({
         params: { crn, id: uuid },
         session: { data: baseSessionData },
@@ -1287,10 +1288,36 @@ describe('checkInsController', () => {
             interval: 'Every week',
             preferredComs: 'Email',
             photoUploadOption: 'Take a photo using this device',
+            rationale: 'Unlikely to reoffend',
           }),
         }),
       )
       expect(mockRenderError).not.toHaveBeenCalled()
+    })
+
+    it('renders summary with rationale hidden when rationale flag is disabled', async () => {
+      mockIsValidCrn.mockReturnValue(true)
+      mockIsValidUUID.mockReturnValue(true)
+      res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: false }
+
+      const req = httpMocks.createRequest({
+        params: { crn, id: uuid },
+        session: { data: baseSessionData },
+      })
+
+      await controllers.checkIns.getCheckinSummaryPage(hmppsAuthClient)(req, res)
+
+      expect(renderSpy).toHaveBeenCalledWith(
+        'pages/check-in/checkin-summary.njk',
+        expect.objectContaining({
+          crn,
+          id: uuid,
+          isRationaleEnabled: false,
+          userDetails: expect.objectContaining({
+            rationale: 'Unlikely to reoffend',
+          }),
+        }),
+      )
     })
 
     it('returns 404 when CRN is invalid', async () => {

--- a/server/controllers/check-ins.test.ts
+++ b/server/controllers/check-ins.test.ts
@@ -563,6 +563,8 @@ describe('checkInsController', () => {
     })
 
     it('redirects rationale page to case overview when rationale flag is off', async () => {
+      mockIsValidCrn.mockReturnValue(true)
+      mockIsValidUUID.mockReturnValue(true)
       const req = baseReq()
 
       res.locals.flags = { enableEsupervisionRationale: false }

--- a/server/controllers/check-ins.ts
+++ b/server/controllers/check-ins.ts
@@ -221,7 +221,11 @@ const checkInsController: Controller<typeof routes, void> = {
       if (eligibilityChoice === 'REPLACE_F2F') {
         return res.redirect(`/case/${crn}/appointments/${id}/check-in/spo-approval`)
       }
-      return res.redirect(`/case/${crn}/appointments/${id}/check-in/rationale`)
+      const isRationaleEnabled = res.locals.flags?.enableEsupervisionRationale === true
+      if (isRationaleEnabled) {
+        return res.redirect(`/case/${crn}/appointments/${id}/check-in/rationale`)
+      }
+      return res.redirect(`/case/${crn}/appointments/${id}/check-in/date-frequency`)
     }
   },
 
@@ -296,7 +300,9 @@ const checkInsController: Controller<typeof routes, void> = {
   getRationalePage: hmppsAuthClient => {
     return async (req, res) => {
       const { crn, id } = req.params as Record<string, string>
-      if (res.locals.flags.enableEsupervisionRationale === false) {
+      const isRationaleEnabled = res.locals.flags?.enableEsupervisionRationale === true
+
+      if (!isRationaleEnabled) {
         return res.redirect(`/case/${crn}`)
       }
       const cya = req.query.cya === 'true'

--- a/server/controllers/check-ins.ts
+++ b/server/controllers/check-ins.ts
@@ -306,7 +306,7 @@ const checkInsController: Controller<typeof routes, void> = {
       let backLink: string
       if (cya) {
         backLink = `/case/${crn}/appointments/${id}/check-in/checkin-summary`
-      } else if (eligibilityChoice === 'replacement-contact') {
+      } else if (eligibilityChoice === 'REPLACE_F2F') {
         backLink = `/case/${crn}/appointments/${id}/check-in/spo-approval`
       } else if (eligibilityArray.includes('eligibility-none')) {
         backLink = `/case/${crn}/appointments/${id}/check-in/full-eligibility`

--- a/server/controllers/check-ins.ts
+++ b/server/controllers/check-ins.ts
@@ -43,6 +43,8 @@ const routes = [
   'postSupplementaryEligibilityPage',
   'getSPOApprovalPage',
   'postSPOApprovalPage',
+  'getRationalePage',
+  'postRationalePage',
   'getDateFrequencyPage',
   'postDateFrequencyPage',
   'getContactPreferencePage',
@@ -219,7 +221,7 @@ const checkInsController: Controller<typeof routes, void> = {
       if (eligibilityChoice === 'replacement-contact') {
         return res.redirect(`/case/${crn}/appointments/${id}/check-in/spo-approval`)
       }
-      return res.redirect(`/case/${crn}/appointments/${id}/check-in/date-frequency`)
+      return res.redirect(`/case/${crn}/appointments/${id}/check-in/rationale`)
     }
   },
 
@@ -243,6 +245,10 @@ const checkInsController: Controller<typeof routes, void> = {
         return renderError(404)(req, res)
       }
       setDataValue(data, ['esupervision', crn, id, 'checkins', 'id'], id)
+      const isRationaleEnabled = res.locals.flags?.enableEsupervisionRationale === true
+      if (isRationaleEnabled) {
+        return res.redirect(`/case/${crn}/appointments/${id}/check-in/rationale`)
+      }
       return res.redirect(`/case/${crn}/appointments/${id}/check-in/date-frequency`)
     }
   },
@@ -278,16 +284,19 @@ const checkInsController: Controller<typeof routes, void> = {
       if (approval) {
         setDataValue(data, ['esupervision', crn, id, 'checkins', 'eligibilitySPOApproval'], approval)
       }
+      const isRationaleEnabled = res.locals.flags?.enableEsupervisionRationale === true
+      if (isRationaleEnabled) {
+        return res.redirect(`/case/${crn}/appointments/${id}/check-in/rationale`)
+      }
       return res.redirect(`/case/${crn}/appointments/${id}/check-in/date-frequency`)
     }
   },
 
-  getDateFrequencyPage: hmppsAuthClient => {
+  getRationalePage: hmppsAuthClient => {
     return async (req, res) => {
       const { crn, id } = req.params as Record<string, string>
-      await sendAuditMessage(res, 'VIEW_MAS_SETUP_ONLINE_CHECK_INS', crn, SubjectType.CRN)
-      if (!isValidCrn(crn) || !isValidUUID(id)) {
-        return renderError(404)(req, res)
+      if (res.locals.flags.enableEsupervisionRationale === false) {
+        return res.redirect(`/case/${crn}`)
       }
       const cya = req.query.cya === 'true'
       const eligibility = req.session.data?.esupervision?.[crn]?.[id]?.checkins?.eligibility || []
@@ -304,6 +313,56 @@ const checkInsController: Controller<typeof routes, void> = {
         backLink = `/case/${crn}/appointments/${id}/check-in/supplementary-eligibility`
       }
 
+      await sendAuditMessage(res, 'VIEW_MAS_RATIONALE_TO_USE_CHECK_INS', crn, SubjectType.CRN)
+      if (!isValidCrn(crn) || !isValidUUID(id)) return renderError(404)(req, res)
+
+      return res.render('pages/check-in/rationale.njk', {
+        crn,
+        id,
+        backLink,
+      })
+    }
+  },
+
+  postRationalePage: hmppsAuthClient => {
+    return async (req, res) => {
+      const { crn, id } = req.params as Record<string, string>
+      const { data } = req.session
+      if (!isValidCrn(crn) || !isValidUUID(id)) {
+        return renderError(404)(req, res)
+      }
+      return res.redirect(`/case/${crn}/appointments/${id}/check-in/date-frequency`)
+    }
+  },
+
+  getDateFrequencyPage: hmppsAuthClient => {
+    return async (req, res) => {
+      const { crn, id } = req.params as Record<string, string>
+      await sendAuditMessage(res, 'VIEW_MAS_SETUP_ONLINE_CHECK_INS', crn, SubjectType.CRN)
+      if (!isValidCrn(crn) || !isValidUUID(id)) {
+        return renderError(404)(req, res)
+      }
+      const cya = req.query.cya === 'true'
+      let backLink: string
+      const isRationaleEnabled = res.locals.flags?.enableEsupervisionRationale === true
+      if (!isRationaleEnabled) {
+        const eligibility = req.session.data?.esupervision?.[crn]?.[id]?.checkins?.eligibility || []
+        const eligibilityArray = Array.isArray(eligibility) ? eligibility : [eligibility]
+        const eligibilityChoice = req.session.data?.esupervision?.[crn]?.[id]?.checkins?.eligibilityChoice
+        if (cya) {
+          backLink = `/case/${crn}/appointments/${id}/check-in/checkin-summary`
+        } else if (eligibilityChoice === 'replacement-contact') {
+          backLink = `/case/${crn}/appointments/${id}/check-in/spo-approval`
+        } else if (eligibilityArray.includes('eligibility-none')) {
+          backLink = `/case/${crn}/appointments/${id}/check-in/full-eligibility`
+        } else {
+          backLink = `/case/${crn}/appointments/${id}/check-in/supplementary-eligibility`
+        }
+      } else if (cya) {
+        backLink = `/case/${crn}/appointments/${id}/check-in/checkin-summary`
+      } else {
+        backLink = `/case/${crn}/appointments/${id}/check-in/rationale`
+      }
       const checkInMinDate = getMinDate()
 
       return res.render(`pages/check-in/date-frequency.njk`, {
@@ -722,8 +781,9 @@ const checkInsController: Controller<typeof routes, void> = {
         photoUploadOption:
           savedUserDetails.photoUploadOption === 'TAKE_A_PIC' ? 'Take a photo using this device' : 'Upload a photo',
       }
+      const isRationaleEnabled = res.locals.flags?.enableEsupervisionRationale === true
       await sendAuditMessage(res, 'VIEW_MAS_CHECK_IN_SUMMARY', crn, SubjectType.CRN)
-      return res.render('pages/check-in/checkin-summary.njk', { crn, id, userDetails })
+      return res.render('pages/check-in/checkin-summary.njk', { crn, id, userDetails, isRationaleEnabled })
     }
   },
 

--- a/server/controllers/check-ins.ts
+++ b/server/controllers/check-ins.ts
@@ -300,6 +300,7 @@ const checkInsController: Controller<typeof routes, void> = {
   getRationalePage: hmppsAuthClient => {
     return async (req, res) => {
       const { crn, id } = req.params as Record<string, string>
+      if (!isValidCrn(crn) || !isValidUUID(id)) return renderError(404)(req, res)
       const isRationaleEnabled = res.locals.flags?.enableEsupervisionRationale === true
 
       if (!isRationaleEnabled) {
@@ -321,7 +322,6 @@ const checkInsController: Controller<typeof routes, void> = {
       }
 
       await sendAuditMessage(res, 'VIEW_MAS_RATIONALE_TO_USE_CHECK_INS', crn, SubjectType.CRN)
-      if (!isValidCrn(crn) || !isValidUUID(id)) return renderError(404)(req, res)
 
       return res.render('pages/check-in/rationale.njk', {
         crn,
@@ -334,7 +334,6 @@ const checkInsController: Controller<typeof routes, void> = {
   postRationalePage: hmppsAuthClient => {
     return async (req, res) => {
       const { crn, id } = req.params as Record<string, string>
-      const { data } = req.session
       if (!isValidCrn(crn) || !isValidUUID(id)) {
         return renderError(404)(req, res)
       }

--- a/server/data/model/esupervision.ts
+++ b/server/data/model/esupervision.ts
@@ -83,6 +83,7 @@ export interface OffenderInfo {
   checkinInterval: string
   contactPreference: string
   startedAt?: string
+  rationale?: string
 }
 
 export interface LocationInfo {

--- a/server/data/model/featureFlags.ts
+++ b/server/data/model/featureFlags.ts
@@ -17,4 +17,5 @@ export class FeatureFlags {
   enableEMDISentencesShowGPSData?: boolean = undefined
   enableEMDIOverviewShowGPSData?: boolean = undefined
   enableEnforcementContacts?: boolean = undefined
+  enableEsupervisionRationale?: boolean = undefined
 }

--- a/server/middleware/postCheckInDetails.test.ts
+++ b/server/middleware/postCheckInDetails.test.ts
@@ -34,6 +34,7 @@ describe('postCheckInDetails', () => {
         checkInMobile: '07123456789',
         photoUploadOption: '07123456789',
         preferredComs: 'EMAIL',
+        rationale: 'Low risk of offending',
       } as const)
 
     const req: any = {
@@ -55,6 +56,7 @@ describe('postCheckInDetails', () => {
     const res: any = {
       locals: {
         user: overrides?.user ?? { username },
+        flags: { enableEsupervisionRationale: true },
         case: { ...baseCase, ...(overrides?.caseOverrides ?? {}) },
       },
       status: jest.fn().mockReturnThis(),
@@ -100,10 +102,12 @@ describe('postCheckInDetails', () => {
       practitionerId: 'pp-user',
       crn,
       checkinInterval: 'WEEK',
+      rationale: 'Low risk of offending',
     })
     expect(calledWith.firstCheckin).toBe('2025/3/12')
     expect(typeof calledWith.startedAt).toBe('string')
     expect(calledWith.contactPreference).toBe('EMAIL')
+    expect(calledWith.rationale).toBe('Low risk of offending')
 
     expect(getProfilePhotoUploadLocation).toHaveBeenCalledWith(setup, 'image/jpeg', validSha256)
     expect(result).toEqual({ setup, uploadLocation })

--- a/server/middleware/postCheckInDetails.test.ts
+++ b/server/middleware/postCheckInDetails.test.ts
@@ -196,4 +196,23 @@ describe('postCheckInDetails', () => {
     expect(res.json).not.toHaveBeenCalled()
     expect(getProfilePhotoUploadLocation).not.toHaveBeenCalled()
   })
+  it('does not send rationale when rationale flag is disabled', async () => {
+    const { req, res } = buildReqRes()
+    res.locals.flags.enableEsupervisionRationale = false
+
+    jest.spyOn(MasApiClient.prototype, 'getProbationPractitioner').mockResolvedValue({ username: 'pp-user' } as any)
+
+    const setup = { uuid: setupUuid }
+    const postOffenderSetup = jest
+      .spyOn(ESupervisionClient.prototype, 'postOffenderSetup')
+      .mockResolvedValue(setup as any)
+
+    jest
+      .spyOn(ESupervisionClient.prototype, 'getProfilePhotoUploadLocation')
+      .mockResolvedValue({ locationInfo: { url: 'http://upload', method: 'PUT' } } as any)
+
+    await postCheckInDetails(hmppsAuthClient)(req, res)
+
+    expect(postOffenderSetup.mock.calls[0][0]).not.toHaveProperty('rationale')
+  })
 })

--- a/server/middleware/postCheckInDetails.ts
+++ b/server/middleware/postCheckInDetails.ts
@@ -11,6 +11,7 @@ export const postCheckInDetails = (
   hmppsAuthClient: HmppsAuthClient,
 ): Route<Promise<{ setup: OffenderSetup; uploadLocation: UploadLocationResponse }>> => {
   return async (req, res) => {
+    const isRationaleEnabled = res.locals.flags?.enableEsupervisionRationale === true
     const { crn, id } = req.params as Record<string, string>
     // The browser sends a base64-encoded SHA-256 digest (see assets/js/photo.js sha256Base64).
     // S3 enforces the matching x-amz-checksum-sha256 on the PUT, so we only guard presence here.
@@ -41,6 +42,9 @@ export const postCheckInDetails = (
       checkinInterval: savedUserDetails.interval,
       startedAt: new Date().toISOString(),
       contactPreference: savedUserDetails.preferredComs,
+      ...(isRationaleEnabled && {
+        rationale: savedUserDetails.rationale,
+      }),
     }
     logger.info('Checkin Registration started')
     try {

--- a/server/middleware/validation/eSuperVision.test.ts
+++ b/server/middleware/validation/eSuperVision.test.ts
@@ -7,6 +7,7 @@ const id = '1'
 
 const checkInUrl = `/case/${crn}/appointments/${id}/check-in`
 
+const rationaleUrl = `${checkInUrl}/rationale`
 const dateFrequencyUrl = `${checkInUrl}/date-frequency`
 const contactPreferenceUrl = `${checkInUrl}/contact-preference`
 const editContactPreferenceUrl = `${checkInUrl}/edit-contact-preference`
@@ -176,6 +177,101 @@ describe('Test eSuperVision validation', () => {
       const req = makeReq({ url: dateFrequencyUrl, body: { esupervision: {} }, session: { data: {} } })
       const res = makeRes()
       validation.eSuperVision(req, res, next)
+      expect(res.render).toHaveBeenCalled()
+    })
+  })
+
+  describe('Test rationale', () => {
+    it('passes with valid rationale entry', () => {
+      const esupervision = {
+        [crn]: {
+          [id]: {
+            checkins: {
+              rationale: 'Unlikely to reoffend',
+            },
+          },
+        },
+      }
+      const req = makeReq({ url: rationaleUrl, body: { esupervision }, session: { data: { esupervision } } })
+      const res = makeRes()
+      validation.eSuperVision(req, res, next)
+      expect(next).toHaveBeenCalled()
+    })
+
+    it('fails and sets summary backLink when cya=true', () => {
+      const req = makeReq({
+        url: `${rationaleUrl}?cya=true`,
+        body: { esupervision: {} },
+        session: { data: {} },
+        query: { cya: 'true' },
+      })
+      const res = makeRes()
+
+      validation.eSuperVision(req, res, next)
+
+      expect(res.locals.backLink).toBe(`/case/${crn}/appointments/${id}/check-in/checkin-summary`)
+      expect(res.render).toHaveBeenCalled()
+    })
+
+    it('fails and sets SPO approval backLink when replacing F2F', () => {
+      const esupervision = {
+        [crn]: {
+          [id]: {
+            checkins: {
+              eligibilityChoice: 'REPLACE_F2F',
+            },
+          },
+        },
+      }
+
+      const req = makeReq({
+        url: rationaleUrl,
+        body: { esupervision: {} },
+        session: { data: { esupervision } },
+      })
+      const res = makeRes()
+
+      validation.eSuperVision(req, res, next)
+
+      expect(res.locals.backLink).toBe(`/case/${crn}/appointments/${id}/check-in/spo-approval`)
+      expect(res.render).toHaveBeenCalled()
+    })
+
+    it('fails and sets full eligibility backLink when eligibility-none was selected', () => {
+      const esupervision = {
+        [crn]: {
+          [id]: {
+            checkins: {
+              eligibility: ['eligibility-none'],
+            },
+          },
+        },
+      }
+
+      const req = makeReq({
+        url: rationaleUrl,
+        body: { esupervision: {} },
+        session: { data: { esupervision } },
+      })
+      const res = makeRes()
+
+      validation.eSuperVision(req, res, next)
+
+      expect(res.locals.backLink).toBe(`/case/${crn}/appointments/${id}/check-in/full-eligibility`)
+      expect(res.render).toHaveBeenCalled()
+    })
+
+    it('fails and sets supplementary eligibility backLink by default', () => {
+      const req = makeReq({
+        url: rationaleUrl,
+        body: { esupervision: {} },
+        session: { data: {} },
+      })
+      const res = makeRes()
+
+      validation.eSuperVision(req, res, next)
+
+      expect(res.locals.backLink).toBe(`/case/${crn}/appointments/${id}/check-in/supplementary-eligibility`)
       expect(res.render).toHaveBeenCalled()
     })
   })

--- a/server/middleware/validation/eSuperVision.ts
+++ b/server/middleware/validation/eSuperVision.ts
@@ -90,6 +90,20 @@ const eSuperVision: Route<void> = (req, res, next) => {
     }
   }
 
+  const validateRationale = () => {
+    if (baseUrl.includes(`/case/${crn}/appointments/${id}/check-in/rationale`)) {
+      render = `pages/check-in/rationale`
+      errorMessages = validateWithSpec(
+        req,
+        eSuperVisionValidation({
+          crn,
+          id,
+          page: 'rationale',
+        }),
+      )
+    }
+  }
+
   const validateDateFrequency = () => {
     if (baseUrl.includes(`/case/${crn}/appointments/${id}/check-in/date-frequency`)) {
       render = `pages/check-in/date-frequency`
@@ -332,6 +346,7 @@ const eSuperVision: Route<void> = (req, res, next) => {
   validateEligibilityCheck()
   validateEligibilityChoice()
   validateSPOApproval()
+  validateRationale()
   validateDateFrequency()
   validateContactPreference()
   validateEditContactPreference()

--- a/server/middleware/validation/eSuperVision.ts
+++ b/server/middleware/validation/eSuperVision.ts
@@ -93,6 +93,25 @@ const eSuperVision: Route<void> = (req, res, next) => {
   const validateRationale = () => {
     if (baseUrl.includes(`/case/${crn}/appointments/${id}/check-in/rationale`)) {
       render = `pages/check-in/rationale`
+
+      const eligibility = req.session.data?.esupervision?.[crn]?.[id]?.checkins?.eligibility || []
+      const eligibilityArray = Array.isArray(eligibility) ? eligibility : [eligibility]
+      const eligibilityChoice = req.session.data?.esupervision?.[crn]?.[id]?.checkins?.eligibilityChoice
+
+      let backUrl: string
+
+      if (cya) {
+        backUrl = `/case/${crn}/appointments/${id}/check-in/checkin-summary`
+      } else if (eligibilityChoice === 'REPLACE_F2F') {
+        backUrl = `/case/${crn}/appointments/${id}/check-in/spo-approval`
+      } else if (eligibilityArray.includes('eligibility-none')) {
+        backUrl = `/case/${crn}/appointments/${id}/check-in/full-eligibility`
+      } else {
+        backUrl = `/case/${crn}/appointments/${id}/check-in/supplementary-eligibility`
+      }
+
+      res.locals.backLink = backUrl
+
       errorMessages = validateWithSpec(
         req,
         eSuperVisionValidation({
@@ -111,8 +130,12 @@ const eSuperVision: Route<void> = (req, res, next) => {
       const eligibilityArray = Array.isArray(eligibility) ? eligibility : [eligibility]
       const eligibilityChoice = req.session.data?.esupervision?.[crn]?.[id]?.checkins?.eligibilityChoice
       let backUrl: string
+      const isRationaleEnabled = res.locals.flags?.enableEsupervisionRationale === true
+
       if (cya) {
         backUrl = `/case/${crn}/appointments/${id}/check-in/checkin-summary`
+      } else if (isRationaleEnabled) {
+        backUrl = `/case/${crn}/appointments/${id}/check-in/rationale`
       } else if (eligibilityChoice === 'REPLACE_F2F') {
         backUrl = `/case/${crn}/appointments/${id}/check-in/spo-approval`
       } else if (eligibilityArray.includes('eligibility-none')) {

--- a/server/models/ESupervision.ts
+++ b/server/models/ESupervision.ts
@@ -25,6 +25,7 @@ export interface CheckinUserDetails {
   eligibility?: string[]
   eligibilityChoice?: 'replacement-contact' | 'supplementary-contact'
   eligibilitySPOApproval?: any
+  rationale?: string
 }
 
 export interface ManageQuestionsSession {

--- a/server/properties/validation/eSupervision.ts
+++ b/server/properties/validation/eSupervision.ts
@@ -57,6 +57,16 @@ export const eSuperVisionValidation = (args: ESupervisionValidationArgs): Valida
         },
       ],
     },
+    [`[esupervision][${crn}][${id}][checkins][rationale]`]: {
+      optional: page !== 'rationale',
+      checks: [
+        {
+          validator: isNotEmpty,
+          msg: 'Enter why the person is suitable to use online check ins',
+          log: 'Rationale not entered in check in process',
+        },
+      ],
+    },
     [`[esupervision][${crn}][${id}][checkins][date]`]: {
       optional: page !== 'date-frequency',
       checks: [

--- a/server/routes/eSupervisionCheckins.ts
+++ b/server/routes/eSupervisionCheckins.ts
@@ -70,6 +70,18 @@ export default function eSuperVisionCheckInsRoutes(router: Router, { hmppsAuthCl
     controllers.checkIns.postSPOApprovalPage(hmppsAuthClient),
   )
 
+  router.get('/case/:crn/appointments/:id/check-in/rationale', [
+    restrictPageAccess({ requiredValues: ['id'], route: 'setupcheckins' }),
+    controllers.checkIns.getRationalePage(hmppsAuthClient),
+  ])
+  router.post(
+    '/case/:crn/appointments/:id/check-in/rationale',
+    validate.eSuperVision,
+    autoStoreSessionData(hmppsAuthClient),
+    postRedirectWizard(),
+    controllers.checkIns.postRationalePage(hmppsAuthClient),
+  )
+
   router.get('/case/:crn/appointments/:id/check-in/date-frequency', [
     restrictPageAccess({ requiredValues: ['id'], route: 'setupcheckins' }),
     controllers.checkIns.getDateFrequencyPage(hmppsAuthClient),

--- a/server/views/pages/check-in/checkin-summary.njk
+++ b/server/views/pages/check-in/checkin-summary.njk
@@ -6,6 +6,8 @@
 {% set setEmail =  '[esupervision]['+  crn + '][' + id +'][checkins][checkInEmail]' %}
 {% set mobileValue = userDetails.checkInMobile if userDetails.checkInMobile else "No mobile number" %}
 {% set emailValue = userDetails.checkInEmail if userDetails.checkInEmail else "No email address" %}
+{% set rationaleLabel = "Why is " + case.name.forename + " suitable to use online check ins?"  %}
+{% set rationaleVal = userDetails.rationale  %}
 {% set checkInDateLabel = "When would you like " + case.name.forename + " to complete their first online check in?"  %}
 {% set checkInDateVal = userDetails.date | dmyToLongDate  %}
 {% set dateFrequencyLabel = "How often would you like " + case.name.forename + " to check in?"  %}
@@ -13,6 +15,7 @@
 {% set photoOptopionLabel = "How do you want to take a photo of " + case.name.forename + "?"  %}
 {% set photoPersonLabel = "Photo of " + case.name.forename %}
 {% set confirmEndUrl =  '/case/' + crn + '/appointments/' + id + '/check-in/confirm-end' %}
+{% set changeRationaleUrl =  '/case/' + crn + '/appointments/' + id + '/check-in/rationale?cya=true' %}
 {% set changeDateUrl =  '/case/' + crn + '/appointments/' + id + '/check-in/date-frequency?cya=true' %}
 {% set contactPreUrl =  '/case/' + crn + '/appointments/' + id + '/check-in/contact-preference?cya=true' %}
 {% set photoPrefUrl =  '/case/' + crn + '/appointments/' + id + '/check-in/photo-options?cya=true' %}
@@ -76,106 +79,160 @@
         </h2>
     {% endif %}
     {%  block pageContent %}
+    {% set summaryRows = [] %}
+
+    {% if isRationaleEnabled %}
+    {% set _ = summaryRows.push({
+        key: {
+        html: rationaleLabel
+        },
+        value: {
+        html: rationaleVal
+        },
+        actions: {
+        items: [{
+            href: changeRationaleUrl,
+            text: "Change",
+            visuallyHiddenText: "why the person is eligible to use online check ins",
+            attributes: {
+            'data-qa': 'rationaleAction'
+            }
+        }]
+        }
+    }) %}
+    {% endif %}
+
+    {% set _ = summaryRows.push(
+    {
+        key: {
+        html: checkInDateLabel
+        },
+        value: {
+        html: checkInDateVal
+        },
+        actions: {
+        items: [{
+            href: changeDateUrl,
+            text: "Change",
+            visuallyHiddenText: "date",
+            attributes: {
+            'data-qa': 'dateAction'
+            }
+        }]
+        }
+    },
+    {
+        key: {
+        html: dateFrequencyLabel
+        },
+        value: {
+        html: userDetails.interval
+        },
+        actions: {
+        items: [{
+            href: changeDateUrl,
+            text: "Change",
+            visuallyHiddenText: "interval",
+            attributes: {
+            'data-qa': 'intervalAction'
+            }
+        }]
+        }
+    },
+    {
+        key: {
+        html: sendLinkLabel
+        },
+        value: {
+        html: userDetails.preferredComs
+        },
+        actions: {
+        items: [{
+            href: contactPreUrl,
+            text: "Change",
+            visuallyHiddenText: "preferredComs",
+            attributes: {
+            'data-qa': 'preferredComsAction'
+            }
+        }]
+        }
+    },
+    {
+        key: {
+        html: "Mobile number"
+        },
+        value: {
+        html: mobileValue
+        },
+        actions: {
+        items: [{
+            href: contactPreUrl,
+            text: "Change",
+            visuallyHiddenText: "checkInMobile",
+            attributes: {
+            'data-qa': 'checkInMobileAction'
+            }
+        }]
+        }
+    },
+    {
+        key: {
+        html: "Email address"
+        },
+        value: {
+        html: emailValue
+        },
+        actions: {
+        items: [{
+            href: contactPreUrl,
+            text: "Change",
+            visuallyHiddenText: "checkInEmail",
+            attributes: {
+            'data-qa': 'checkInEmailAction'
+            }
+        }]
+        }
+    },
+    {
+        key: {
+        html: photoOptopionLabel
+        },
+        value: {
+        html: userDetails.photoUploadOption
+        },
+        actions: {
+        items: [{
+            href: photoPrefUrl,
+            text: "Change",
+            visuallyHiddenText: "photoUploadOption",
+            attributes: {
+            'data-qa': 'photoUploadOptionAction'
+            }
+        }]
+        }
+    },
+    {
+        key: {
+        html: photoPersonLabel
+        },
+        value: {
+        html: '<div class="es-uploaded-image" data-person="' + case.name.forename + '">&nbsp;</div>'
+        },
+        actions: {
+        items: [{
+            href: photoUrl,
+            text: "Change",
+            visuallyHiddenText: "photo",
+            attributes: {
+            'data-qa': 'photoAction'
+            }
+        }]
+        }
+    }
+    ) %}
+
     {{ govukSummaryList({
-        rows: [
-            { key:
-                { html:  checkInDateLabel  },
-                value: { html:  checkInDateVal },
-                actions: {
-                items: [ {
-                    href: changeDateUrl,
-                    text: "Change",
-                    visuallyHiddenText: "date",
-                    attributes: {
-                        'data-qa': 'dateAction'
-                    }
-                }
-                ]
-            } },
-            { key:
-                { html:  dateFrequencyLabel  },
-                value: { html: userDetails.interval },
-                actions: {
-                items: [ {
-                    href: changeDateUrl,
-                    text: "Change",
-                    visuallyHiddenText: "interval",
-                    attributes: {
-                        'data-qa': 'intervalAction'
-                    }
-                }
-                ]
-            } },
-            { key:
-                { html:  sendLinkLabel  },
-                value: { html: userDetails.preferredComs},
-                actions: {
-                items: [ {
-                    href: contactPreUrl,
-                    text: "Change",
-                    visuallyHiddenText: "preferredComs",
-                    attributes: {
-                        'data-qa': 'preferredComsAction'
-                    }
-                }
-                ]
-            } },
-            { key:
-                { html:  "Mobile number"  },
-                value: { html: mobileValue},
-                actions: {
-                items: [ {
-                    href: contactPreUrl,
-                    text: "Change",
-                    visuallyHiddenText: "checkInMobile",
-                    attributes: {
-                        'data-qa': 'checkInMobileAction'
-                    }
-                }
-                ]
-            } },
-            { key:
-                { html:  "Email address"  },
-                value: { html: emailValue},
-                actions: {
-                items: [ {
-                    href: contactPreUrl,
-                    text: "Change",
-                    visuallyHiddenText: "checkInEmail",
-                    attributes: {
-                        'data-qa': 'checkInEmailAction'
-                    }
-                }
-                ]
-            } },
-            { key:
-                { html:  photoOptopionLabel },
-                value: { html: userDetails.photoUploadOption},
-                actions: {
-                items: [ {
-                    href: photoPrefUrl,
-                    text: "Change",
-                    visuallyHiddenText: "photoUploadOption",
-                    attributes: {
-                        'data-qa': 'photoUploadOptionAction'
-                    }
-                }
-                ]
-            } },
-            { key:
-                { html:  photoPersonLabel },
-                value: { html: '<div class="es-uploaded-image" data-person="' + case.name.forename + '">&nbsp;</div>' },
-                actions: {
-                items: [ {
-                    href: photoUrl,
-                    text: "Change",
-                    visuallyHiddenText: "photo",
-                    attributes: {
-                        'data-qa': 'photoAction'
-                    }
-                } ]
-            } }
-        ]
+    rows: summaryRows
     }) }}
 
     <div class="govuk-!-width-one-half">

--- a/server/views/pages/check-in/checkin-summary.njk
+++ b/server/views/pages/check-in/checkin-summary.njk
@@ -87,7 +87,7 @@
         html: rationaleLabel
         },
         value: {
-        html: rationaleVal
+          html: rationaleVal | escape | nl2br
         },
         actions: {
         items: [{

--- a/server/views/pages/check-in/checkin-summary.njk
+++ b/server/views/pages/check-in/checkin-summary.njk
@@ -93,7 +93,7 @@
         items: [{
             href: changeRationaleUrl,
             text: "Change",
-            visuallyHiddenText: "why the person is eligible to use online check ins",
+            visuallyHiddenText: "why the person is suitable to use online check ins",
             attributes: {
             'data-qa': 'rationaleAction'
             }

--- a/server/views/pages/check-in/rationale.njk
+++ b/server/views/pages/check-in/rationale.njk
@@ -1,9 +1,7 @@
 {% extends "../_form.njk" %}
 
-{% set title = "Why is " + case.name.forename + " suitable to use online check ins?"  %}
+{% set textAreaTitle = "Why is " + case.name.forename + " suitable to use online check ins?"  %}
 {% set hintText = "For example, low risk of reoffending, stable lifestyle factors."  %}
-
-{% set showAnchorLink = true %}
 
 {% block form %}
     <div class="govuk-grid-row">
@@ -14,6 +12,7 @@
                 attributes: { "data-qa": "rationale-for-check-ins"}
             },
             label: {
+                text: textAreaTitle,
                 classes: 'govuk-label--l govuk-!-margin-bottom-3',
                 isPageHeading: true
             },

--- a/server/views/pages/check-in/rationale.njk
+++ b/server/views/pages/check-in/rationale.njk
@@ -1,0 +1,26 @@
+{% extends "../_form.njk" %}
+
+{% set title = "Why is " + case.name.forename + " suitable to use online check ins?"  %}
+{% set hintText = "For example, low risk of reoffending, stable lifestyle factors."  %}
+
+{% set showAnchorLink = true %}
+
+{% block form %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+
+        {{ govukTextarea({
+            formGroup: {
+                attributes: { "data-qa": "rationale-for-check-ins"}
+            },
+            label: {
+                classes: 'govuk-label--l govuk-!-margin-bottom-3',
+                isPageHeading: true
+            },
+            hint: {
+                text: hintText
+            }
+        } | decorateFormAttributes(['esupervision', crn, id, 'checkins', 'rationale'])) }}
+        </div>
+    </div>
+{% endblock %}

--- a/wiremock/mappings/flipt.json
+++ b/wiremock/mappings/flipt.json
@@ -187,6 +187,17 @@
               "updatedAt": "2026-06-12T12:00:00.000000Z",
               "rules": [],
               "rollouts": []
+            },
+            {
+              "key": "enableEsupervisionRationale",
+              "name": "enableEsupervisionRationale",
+              "description": "",
+              "enabled": true,
+              "type": "BOOLEAN_FLAG_TYPE",
+              "createdAt": "2026-06-17T12:00:00.000000Z",
+              "updatedAt": "2026-06-17T12:00:00.000000Z",
+              "rules": [],
+              "rollouts": []
             }
           ]
         }

--- a/wiremock/stubs/flags.ts
+++ b/wiremock/stubs/flags.ts
@@ -416,6 +416,38 @@ const stubDisableEnforcementContacts = (): SuperAgentRequest =>
     },
   })
 
+const stubEnableEsupervisionRationale = (): SuperAgentRequest =>
+  superagent.post('http://localhost:9091/__admin/mappings').send({
+    request: {
+      urlPathPattern: '/flipt/internal/v1/evaluation/snapshot/namespace/manage-people-on-probation-ui',
+      method: 'GET',
+    },
+    response: {
+      status: 200,
+      jsonBody: {
+        namespace: {
+          key: 'manage-people-on-probation-ui',
+        },
+        flags: [
+          {
+            key: 'enableEsupervisionRationale',
+            name: 'enableEsupervisionRationale',
+            description: '',
+            enabled: true,
+            type: 'BOOLEAN_FLAG_TYPE',
+            createdAt: '2026-06-17T12:00:00.000000Z',
+            updatedAt: '2026-06-17T12:00:00.000000Z',
+            rules: [],
+            rollouts: [],
+          },
+        ],
+      },
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    },
+  })
+
 export default {
   stubEnableESuperVision,
   stubDisableSmsReminders,
@@ -428,4 +460,5 @@ export default {
   stubEnableShowMatchWithConcern,
   stubDisableEMDIOverviewShowGPSData,
   stubDisableEnforcementContacts,
+  stubEnableEsupervisionRationale,
 }


### PR DESCRIPTION
[EUSP-1885](https://dsdmoj.atlassian.net/browse/ESUP-1885)

This PR adds the new rationale page which is a required page in the sign up to online check ins journey. It is currently feature flagged behind the flag enableEsupervisionRationale

Practitioners are prompted to type `Why is X suitable to use online check ins?`. There is validation to ensure they do not leave this blank. There is also some custom back link logic to ensure that the back link goes to the correct location based on the steps previously chosen. The value is also displayed in the check answers page at the end of the journey, and practitioners can amend their response and will be taken back to the right page.

<img width="1142" height="710" alt="image" src="https://github.com/user-attachments/assets/41a9c6ab-7ca1-4219-807e-0380ee5bfc58" />
<img width="1113" height="833" alt="image" src="https://github.com/user-attachments/assets/11a4de44-4151-45e9-9858-7cdb23487cc8" />

<img width="1266" height="919" alt="image" src="https://github.com/user-attachments/assets/26994fa8-be59-4737-952d-7838198c22c1" />

