### PR TITLE
{%- strips the newline between the opening <span> tag and the {% if %…

### DIFF
--- a/server/views/_components/note/template.njk
+++ b/server/views/_components/note/template.njk
@@ -1,9 +1,9 @@
 <div class="app-note text-break">
   <p class="govuk-body govuk-!-margin-bottom-1">
     <span class="line-break">
-      {% if notePrefix %}
+      {%- if notePrefix %}
         <span class='govuk-!-font-weight-bold' data-qa="note-prefix-text">{{ notePrefix }}</span>
-      {% endif %}
+      {% endif -%}
       {{ note.note | handleQuotes('unescape') | formatEnforcementActionNote | safe }}</span>
     {% if note.hasNoteBeenTruncated === true %}... <a href="{{ href }}">{{ viewFullNoteText }}</a>
     {% endif %}


### PR DESCRIPTION
{%- strips the newline between the opening <span> tag and the {% if %} block, and -%} strips the newline/spaces between {% endif %} and the note content. This removes the blank-line rendering without affecting the note's internal line breaks.

### After
<img width="1291" height="348" alt="image" src="https://github.com/user-attachments/assets/2c8a8bf0-51a4-4b4c-baf2-93e1db3eb6cb" />

### Before
<img width="1291" height="348" alt="image" src="https://github.com/user-attachments/assets/897b9633-e59b-41a6-b29f-291e4c69ab34" />
