### PR TITLE
[ESUP-1951] Update change links for check in summary page

### DIFF
--- a/server/views/pages/check-in/checkin-summary.njk
+++ b/server/views/pages/check-in/checkin-summary.njk
@@ -114,7 +114,7 @@
         items: [{
             href: changeDateUrl,
             text: "Change",
-            visuallyHiddenText: "date",
+            visuallyHiddenText: "when would you like the person to start using online check ins",
             attributes: {
             'data-qa': 'dateAction'
             }
@@ -132,7 +132,7 @@
         items: [{
             href: changeDateUrl,
             text: "Change",
-            visuallyHiddenText: "interval",
+            visuallyHiddenText: "how often would you like the person to check in",
             attributes: {
             'data-qa': 'intervalAction'
             }
@@ -150,7 +150,7 @@
         items: [{
             href: contactPreUrl,
             text: "Change",
-            visuallyHiddenText: "preferredComs",
+            visuallyHiddenText: "how does the person want us to send them a link",
             attributes: {
             'data-qa': 'preferredComsAction'
             }
@@ -168,7 +168,7 @@
         items: [{
             href: contactPreUrl,
             text: "Change",
-            visuallyHiddenText: "checkInMobile",
+            visuallyHiddenText: "what is the person's mobile number",
             attributes: {
             'data-qa': 'checkInMobileAction'
             }
@@ -186,7 +186,7 @@
         items: [{
             href: contactPreUrl,
             text: "Change",
-            visuallyHiddenText: "checkInEmail",
+            visuallyHiddenText: "what is the person's email address",
             attributes: {
             'data-qa': 'checkInEmailAction'
             }
@@ -204,7 +204,7 @@
         items: [{
             href: photoPrefUrl,
             text: "Change",
-            visuallyHiddenText: "photoUploadOption",
+            visuallyHiddenText: "how do you want to take a photo of the person",
             attributes: {
             'data-qa': 'photoUploadOptionAction'
             }
@@ -222,7 +222,7 @@
         items: [{
             href: photoUrl,
             text: "Change",
-            visuallyHiddenText: "photo",
+            visuallyHiddenText: "photo of the person",
             attributes: {
             'data-qa': 'photoAction'
             }


### PR DESCRIPTION
[ESUP-1951](https://dsdmoj.atlassian.net/browse/ESUP-1951)
Minor visually-hidden content change to the change links in the checkin-summary page so that screen reader users can efficiently navigate the page and identify the correct action.

There will be future PRs addressing the change links in the restart check in journey and the overview pages once the content design has been confirmed.

[ESUP-1951]: https://dsdmoj.atlassian.net/browse/ESUP-1951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ