### PR TITLE
MAN-2966 add prepend text to note in put request body

### DIFF
--- a/server/middleware/appointment-outcomes/getConfirmation.ts
+++ b/server/middleware/appointment-outcomes/getConfirmation.ts
@@ -1,8 +1,7 @@
 import { Route } from '../../@types'
 import { Activity } from '../../data/model/schedule'
 import { AppointmentEnforcementAction, AppointmentOutcomeType } from '../../models/Appointments'
-import { dateWithYear, dayOfWeek } from '../../utils'
-import { to12HourTimeCompact } from '../../utils/to12HourTimeCompact'
+import { dateWithYear, dayOfWeek, govukTime } from '../../utils'
 import { enforcementActionMap } from '../../properties/appointment-outcomes'
 import type { OutcomeConfirmationAction, OutcomeConfirmation, AppointmentOutcomeProps } from '../../models/Locals'
 import config from '../../config'
@@ -26,7 +25,7 @@ export const getConfirmation: Route<void> = (req, res, next): void => {
   let text = [diaryActionText]
   const { date, start, end } = appointmentSession
   const type = appointment?.type || null
-  const appointmentDate = `${dayOfWeek(date)} ${dateWithYear(date)} from ${to12HourTimeCompact(start)} to ${to12HourTimeCompact(end)}`
+  const appointmentDate = `${dayOfWeek(date)} ${dateWithYear(date)} from ${govukTime(start)} to ${govukTime(end)}`
 
   // Attended and complied, Attended but sent home due to service issues, Acceptable absence 👇
 

--- a/server/middleware/appointment-outcomes/handlePutOutcome.test.ts
+++ b/server/middleware/appointment-outcomes/handlePutOutcome.test.ts
@@ -50,8 +50,6 @@ const token = { access_token: 'token-1', expires_in: 300 }
 const tokenStore = new TokenStore(null) as jest.Mocked<TokenStore>
 const hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
 tokenStore.getToken.mockResolvedValue(token.access_token)
-
-const findUncompletedSpy = findUncompleted as jest.MockedFunction<typeof findUncompleted>
 const putContactSpy = jest.spyOn(MasApiClient.prototype, 'putContact').mockResolvedValue({} as any)
 
 const mockAppointment = ({
@@ -172,9 +170,9 @@ describe('middleware/appointment-outcomes/handlePutOutcome', () => {
     await handlePutOutcome(hmppsAuthClient)(req, res, nextSpy)
     expect(res.redirect).toHaveBeenCalledWith(`${baseOutcomeUrl}?validation=true`)
   })
-  it('should put the correct request to the API if no notes and no enforcement action codes selected', async () => {
+  it('should put the correct request to the API if no notes, and no enforcement action codes selected', async () => {
     const req = buildRequest()
-    const res = buildResponse()
+    const res = buildResponse({ appointmentOutcome: { notePrepend: '' } })
     await handlePutOutcome(hmppsAuthClient)(req, res, nextSpy)
     const {
       date,
@@ -193,7 +191,7 @@ describe('middleware/appointment-outcomes/handlePutOutcome', () => {
     expect(nextSpy).toHaveBeenCalledTimes(1)
   })
 
-  it('should put the correct request to the API if notePrepend value exists and a single enforcement action is selected', async () => {
+  it('should put the correct request to the API if notes, notePrepend value exists and a single enforcement action is selected', async () => {
     const appointment: Partial<AppointmentSession> = { notes }
     const outcome: Partial<AppointmentSessionOutcome> = {
       outcomeType: 'ATTENDED_FAILED_TO_COMPLY',
@@ -204,17 +202,39 @@ describe('middleware/appointment-outcomes/handlePutOutcome', () => {
     const req = buildRequest()
     const res = buildResponse({ appointment, outcome })
     await handlePutOutcome(hmppsAuthClient)(req, res, nextSpy)
-    const {
-      date,
-      start,
-      outcome: { outcomeCode },
-    } = mockAppointment()
+    const { date, start } = mockAppointment()
     const expectedRequest: PutContactRequest = {
       date,
       time: start,
       outcomeCode: outcome.outcomeCode,
       enforcementActionCode: 'IBR',
       notes: `${notePrepend}\n${notes}`,
+      sensitive: true,
+      alert: false,
+    }
+    expect(putContactSpy).toHaveBeenCalledWith(contactId, expectedRequest)
+    expect(putContactSpy).toHaveBeenCalledTimes(1)
+    expect(nextSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('should put the correct request to the API if no notes, notePrepend value exists and a single enforcement action is selected', async () => {
+    const appointment: Partial<AppointmentSession> = { notes: '' }
+    const outcome: Partial<AppointmentSessionOutcome> = {
+      outcomeType: 'ATTENDED_FAILED_TO_COMPLY',
+      outcomeCode: 'AFTC',
+      attendedFailedToComply: 'BREACH_RECALL_INITIATED',
+      enforcementActionCode: ['IBR'],
+    }
+    const req = buildRequest()
+    const res = buildResponse({ appointment, outcome })
+    await handlePutOutcome(hmppsAuthClient)(req, res, nextSpy)
+    const { date, start } = mockAppointment()
+    const expectedRequest: PutContactRequest = {
+      date,
+      time: start,
+      outcomeCode: outcome.outcomeCode,
+      enforcementActionCode: 'IBR',
+      notes: notePrepend,
       sensitive: true,
       alert: false,
     }

--- a/server/middleware/appointment-outcomes/handlePutOutcome.ts
+++ b/server/middleware/appointment-outcomes/handlePutOutcome.ts
@@ -4,23 +4,14 @@ import MasApiClient from '../../data/masApiClient'
 import { PutContactRequest } from '../../data/model/schedule'
 import { AppointmentOutcomeType } from '../../models/Appointments'
 import { handleQuotes } from '../../utils'
-import { findUncompleted } from '../findUncompleted'
 import { renderError } from '../renderError'
 
 type PutContactPromise = ReturnType<MasApiClient['putContact']>
 
 export const handlePutOutcome = (hmppsAuthClient: HmppsAuthClient): Route<Promise<void>> => {
   return async (req, res, next) => {
-    const {
-      appointmentSession,
-      notePrepend,
-      contactId,
-      uuid,
-      isValidParams,
-      baseOutcomeUrl,
-      responseContactId,
-      isInPast,
-    } = res.locals.appointmentOutcome
+    const { appointmentSession, notePrepend, contactId, isValidParams, baseOutcomeUrl, responseContactId, isInPast } =
+      res.locals.appointmentOutcome
 
     /*
      only send request if putting outcome for arranged/rescheduled appt in the past or 
@@ -40,8 +31,8 @@ export const handlePutOutcome = (hmppsAuthClient: HmppsAuthClient): Route<Promis
       const sensitivity = appointmentSession?.sensitivity
       const enforcementActionCode = appointmentSession?.outcome?.enforcementActionCode
       let notes = appointmentSession?.notes || ''
-      if (notes && notePrepend) {
-        notes = `${notePrepend}\n${notes}`
+      if (notePrepend) {
+        notes = `${notePrepend}${notes ? `\n${notes}` : ''}`
       }
       const sensitive = appointmentSession?.sensitivity === 'Yes'
       const token = await hmppsAuthClient.getSystemClientToken(res.locals.user.username)

--- a/server/routes/appointmentOutcomes.ts
+++ b/server/routes/appointmentOutcomes.ts
@@ -305,15 +305,6 @@ export default function appointmentOutcomesRoutes(router: Router, { hmppsAuthCli
   )
   router.post(`${manageBasePath}/update-enforcement-action`, handleOutcomePageRedirect('updateEnforcementAction'))
 
-  /* Add note page in arrange journey (no file upload) 👇 */
-
-  router.get(
-    `${arrangeBasePath}/add-note`,
-    forceValidation,
-    controllers.appointmentOutcomes.getAddNote(hmppsAuthClient),
-  )
-  router.post([`${arrangeBasePath}/add-note`], controllers.appointmentOutcomes.postAddNote(hmppsAuthClient))
-
   router.all(
     `${manageBasePath}/next-appointment`,
     getNextComAppointment(hmppsAuthClient),
@@ -329,10 +320,11 @@ export default function appointmentOutcomesRoutes(router: Router, { hmppsAuthCli
     controllers.appointments.postNextAppointment(hmppsAuthClient),
   )
 
+  router.all(`${manageBasePath}/check-your-answers`, getNotePrepend)
+
   router.get(
     `${manageBasePath}/check-your-answers`,
     getNextComAppointment(hmppsAuthClient),
-    getNotePrepend,
     getOutcomeSummary,
     controllers.appointmentOutcomes.getCheckYourAnswers(hmppsAuthClient),
   )
@@ -342,9 +334,18 @@ export default function appointmentOutcomesRoutes(router: Router, { hmppsAuthCli
     controllers.appointmentOutcomes.postCheckYourAnswers(hmppsAuthClient),
   )
 
+  /* Add note page in arrange journey (no file upload) 👇 */
+
   router.all(`${arrangeBasePath}/add-note`, getNotePrepend)
-  router.get(`${arrangeBasePath}/add-note`, controllers.appointmentOutcomes.getAddNote(hmppsAuthClient))
+  router.get(
+    `${arrangeBasePath}/add-note`,
+    forceValidation,
+    controllers.appointmentOutcomes.getAddNote(hmppsAuthClient),
+  )
   router.post([`${arrangeBasePath}/add-note`], controllers.appointmentOutcomes.postAddNote(hmppsAuthClient))
+
+  /* Confirmation 👇 */
+
   router.get(
     `${manageBasePath}/confirmation`,
     getOverdueOutcomes(hmppsAuthClient),


### PR DESCRIPTION
Fixes bug where prepend text for who will send letter/breach/recall was not being added to notes value in PUT request body