### PR TITLE
MAN-2971: Show Manage link for updatable contacts without outcomes

### DIFF
--- a/integration_tests/e2e/activityLog.cy.ts
+++ b/integration_tests/e2e/activityLog.cy.ts
@@ -642,4 +642,16 @@ context('Contacts', () => {
     page.getElementByDataQA('manage-on-delius-link').should('not.exist')
     page.getActivityViewLink(0).should('contain.text', 'Manage')
   })
+
+  it('should show Manage link for updatable contacts without outcomes in compact view', () => {
+    cy.task('stubActivityLogWithUpdatableContactNoOutcome')
+    cy.visit('/case/X000001/activity-log')
+    const page = Page.verifyOnPage(ActivityLogPage)
+    cy.get('.govuk-table').should('exist')
+    // Updatable contact without outcome should show Manage link, not outcome prompt
+    page.getActivity(1).should('contain.text', 'MAPPA level setting process')
+    page.getActivityViewLink(0).should('contain.text', 'Manage')
+    // Verify it's NOT showing outcome prompt (View + Manage on NDelius)
+    cy.get('.contact-activity__actions-cell').eq(0).find('[data-qa="manage-on-delius-link"]').should('not.exist')
+  })
 })

--- a/integration_tests/e2e/activityLog.cy.ts
+++ b/integration_tests/e2e/activityLog.cy.ts
@@ -642,4 +642,14 @@ context('Contacts', () => {
     page.getElementByDataQA('manage-on-delius-link').should('not.exist')
     page.getActivityViewLink(0).should('contain.text', 'Manage')
   })
+
+  it('should show Manage link for updatable contacts without outcomes in compact view', () => {
+    cy.visit('/case/X000001/activity-log')
+    const page = Page.verifyOnPage(ActivityLogPage)
+    cy.get('.govuk-table').should('exist')
+    // Find an updatable contact without outcome (e.g., from the mock data)
+    // and verify it shows "Manage" link, not an outcome prompt
+    page.getActivityViewLink(0).should('contain.text', 'Manage')
+    page.getElementByDataQA('manage-on-delius-link').should('not.exist')
+  })
 })

--- a/integration_tests/e2e/activityLog.cy.ts
+++ b/integration_tests/e2e/activityLog.cy.ts
@@ -642,14 +642,4 @@ context('Contacts', () => {
     page.getElementByDataQA('manage-on-delius-link').should('not.exist')
     page.getActivityViewLink(0).should('contain.text', 'Manage')
   })
-
-  it('should show Manage link for updatable contacts without outcomes in compact view', () => {
-    cy.visit('/case/X000001/activity-log')
-    const page = Page.verifyOnPage(ActivityLogPage)
-    cy.get('.govuk-table').should('exist')
-    // Find an updatable contact without outcome (e.g., from the mock data)
-    // and verify it shows "Manage" link, not an outcome prompt
-    page.getActivityViewLink(0).should('contain.text', 'Manage')
-    page.getElementByDataQA('manage-on-delius-link').should('not.exist')
-  })
 })

--- a/server/views/pages/contact-log/_compact-timeline-entry.njk
+++ b/server/views/pages/contact-log/_compact-timeline-entry.njk
@@ -1,5 +1,5 @@
 {% set hasAppointmentStartTimePassed = isInThePast(entry.startDateTime) %}
-{% set shouldPromptToRecordAnOutcome = entry.hasOutcome === false and hasAppointmentStartTimePassed %}
+{% set shouldPromptToRecordAnOutcome = entry.isAppointment and not entry.isUpdatableContact and entry.hasOutcome === false and hasAppointmentStartTimePassed %}
 {% set link = '/case/' + crn + '/activity/' + entry.id + '?back=' + url %}
 {% if entry.isAppointment %}
   {% set link = '/case/' + crn + '/appointments/appointment/' + entry.id + '/manage?back=' + url %}

--- a/server/views/pages/contact-log/_compact-timeline-entry.njk
+++ b/server/views/pages/contact-log/_compact-timeline-entry.njk
@@ -1,5 +1,5 @@
 {% set hasAppointmentStartTimePassed = isInThePast(entry.startDateTime) %}
-{% set shouldPromptToRecordAnOutcome = entry.isAppointment and not entry.isUpdatableContact and entry.hasOutcome === false and hasAppointmentStartTimePassed %}
+{% set shouldPromptToRecordAnOutcome = not entry.isUpdatableContact and entry.hasOutcome === false and hasAppointmentStartTimePassed %}
 {% set link = '/case/' + crn + '/activity/' + entry.id + '?back=' + url %}
 {% if entry.isAppointment %}
   {% set link = '/case/' + crn + '/appointments/appointment/' + entry.id + '/manage?back=' + url %}

--- a/wiremock/stubs/activityLog.ts
+++ b/wiremock/stubs/activityLog.ts
@@ -319,6 +319,55 @@ const stubActivityLogWithUnplannedContact = (): SuperAgentRequest =>
     },
   })
 
+const stubActivityLogWithUpdatableContactNoOutcome = (): SuperAgentRequest =>
+  superagent.post('http://localhost:9091/__admin/mappings').send({
+    request: {
+      urlPathPattern: '/mas/activity/X000001',
+      method: 'POST',
+      queryParameters: {
+        page: { matches: '.*' },
+        size: { equalTo: '25' },
+      },
+    },
+    response: {
+      status: 200,
+      jsonBody: {
+        size: 1,
+        page: 0,
+        totalResults: 1,
+        totalPages: 1,
+        personSummary: {
+          name: { forename: 'Eula', surname: 'Schmeler' },
+          crn: 'X000001',
+          dateOfBirth: '1979-08-18',
+        },
+        activities: [
+          {
+            id: 9997,
+            eventNumber: '4',
+            type: 'MAPPA Level setting process',
+            displayName: 'MAPPA level setting process',
+            startDateTime: '2024-01-10T10:00:00.000Z',
+            isSensitive: false,
+            hasOutcome: false,
+            wasAbsent: false,
+            isAppointment: false,
+            isCommunication: false,
+            isSystemContact: false,
+            deliusManaged: true,
+            isUpdatableContact: true,
+            isInPast: true,
+            appointmentNotes: [],
+            officer: { name: { forename: 'Paul', surname: 'Smith' } },
+            lastUpdated: '2024-01-15',
+            lastUpdatedBy: { forename: 'Paul', surname: 'Smith' },
+          },
+        ],
+      },
+      headers: { 'Content-Type': 'application/json' },
+    },
+  })
+
 export default {
   stubAppointmentNoOutcomeWithNote,
   stubAppointmentOutcomeWithNote,
@@ -326,4 +375,5 @@ export default {
   stubAppointmentDeepLinkWithOutcome,
   stubActivityLogWithAlcoholConsumption,
   stubActivityLogWithUnplannedContact,
+  stubActivityLogWithUpdatableContactNoOutcome,
 }


### PR DESCRIPTION
 ## Summary
 - Fix outcome prompt showing incorrectly for updatable contacts in activity log
 - Updatable contacts (e.g., MAPPA Level setting process) now show "Manage" linkinstead of outcome prompt