### PR TITLE
Consolidate actions checkout v7

### DIFF
--- a/.github/workflows/build_subproject.yml
+++ b/.github/workflows/build_subproject.yml
@@ -32,7 +32,7 @@ jobs:
         project:
           - feature-flags
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set version
         id: version

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ jobs:
       packages: read
       statuses: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Lint changes

--- a/.github/workflows/deploy_subproject.yml
+++ b/.github/workflows/deploy_subproject.yml
@@ -48,7 +48,7 @@ jobs:
     environment:
       name: ${{ inputs.environment }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/get-env-details
         id: env
         with:

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -48,7 +48,7 @@ jobs:
     outputs:
       version: ${{ steps.app_version.outputs.version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - id: app_version
         name: Application version creators
         uses: ./.github/actions/create_app_version # WORKFLOW_VERSION

--- a/.github/workflows/node_build.yml
+++ b/.github/workflows/node_build.yml
@@ -22,7 +22,7 @@ jobs:
     name: Run the node build 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
     - name: Use Node.js ${{ inputs.node_version_file }}
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
       with:

--- a/.github/workflows/node_integration_tests.yml
+++ b/.github/workflows/node_integration_tests.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         shard: [1, 2, 3]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Use Node.js ${{ inputs.node_version_file }}
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/pipeline_scan.yml
+++ b/.github/workflows/pipeline_scan.yml
@@ -77,7 +77,7 @@ jobs:
       java_options: "-Xmx1024m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process"
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/policy_scan.yml
+++ b/.github/workflows/policy_scan.yml
@@ -87,7 +87,7 @@ jobs:
       java_options: "-Xmx1024m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process"
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,7 +19,7 @@ jobs:
       CONFIG_FILE: ${{ github.workspace }}/.zap/autorun.yml
       REPORT_DIR: ${{ github.workspace }}/.zap/zap-report
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup ZAP
         uses: ./.github/actions/setup-zap

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -6,7 +6,7 @@ jobs:
     name: SonarCloud
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - name: download the coverage artifacts

--- a/.github/workflows/veracode_pipeline_scan.yml
+++ b/.github/workflows/veracode_pipeline_scan.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Package build output
         run: |


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` from v6 to v7 across all CI/CD workflows
- Includes ESM migration and improved security for fork PR handling
- Consolidates dependabot PR #1692 into a single coherent update