### PR TITLE
MTRSB-105: Fix `TypeError` when creating appointments by adding missi…

### DIFF
--- a/server/middleware/getDefaultUser.ts
+++ b/server/middleware/getDefaultUser.ts
@@ -72,7 +72,7 @@ export const getDefaultUser = (hmppsAuthClient: HmppsAuthClient): Route<Promise<
       }
       const appointmentStaff = await masClient.getStaffByTeam(teamCode)
       const ppStaff = appointmentStaff.users.find(
-        user => user?.username?.toLowerCase() === probationPractitioner?.username.toLowerCase(),
+        user => user?.username?.toLowerCase() === probationPractitioner?.username?.toLowerCase(),
       )
       if (ppStaff && !sessionStaff.some(u => u?.username?.toLowerCase() === ppStaff.username?.toLowerCase())) {
         sessionStaff.push(ppStaff)

--- a/server/middleware/getDefaultUser.ts
+++ b/server/middleware/getDefaultUser.ts
@@ -71,11 +71,11 @@ export const getDefaultUser = (hmppsAuthClient: HmppsAuthClient): Route<Promise<
         setDataValue(data, ['appointments', crn, id, 'user', 'name'], attendingName)
       }
       const appointmentStaff = await masClient.getStaffByTeam(teamCode)
-      const ppStaff = appointmentStaff.users.find(
-        user =>
-          probationPractitioner?.username &&
-          user?.username?.toLowerCase() === probationPractitioner.username.toLowerCase(),
-      )
+      const ppStaff = probationPractitioner?.username
+        ? appointmentStaff.users.find(
+            user => user?.username?.toLowerCase() === probationPractitioner.username.toLowerCase(),
+          )
+        : undefined
       if (ppStaff && !sessionStaff.some(u => u?.username?.toLowerCase() === ppStaff.username?.toLowerCase())) {
         sessionStaff.push(ppStaff)
       }

--- a/server/middleware/getDefaultUser.ts
+++ b/server/middleware/getDefaultUser.ts
@@ -72,7 +72,9 @@ export const getDefaultUser = (hmppsAuthClient: HmppsAuthClient): Route<Promise<
       }
       const appointmentStaff = await masClient.getStaffByTeam(teamCode)
       const ppStaff = appointmentStaff.users.find(
-        user => user?.username?.toLowerCase() === probationPractitioner?.username?.toLowerCase(),
+        user =>
+          probationPractitioner?.username &&
+          user?.username?.toLowerCase() === probationPractitioner.username.toLowerCase(),
       )
       if (ppStaff && !sessionStaff.some(u => u?.username?.toLowerCase() === ppStaff.username?.toLowerCase())) {
         sessionStaff.push(ppStaff)


### PR DESCRIPTION
 ## Summary
 - Fix `TypeError` when creating appointments by adding missing optional chaining on `probationPractitioner?.username`
 - Prevents crash when username is undefined on the probation practitioner object