### PR TITLE
[ESUP-1952] - Update change links for Check your answers before restarting online check ins

### DIFF
--- a/server/views/pages/check-in/manage/restart-checkin-summary.njk
+++ b/server/views/pages/check-in/manage/restart-checkin-summary.njk
@@ -74,7 +74,7 @@
                 items: [ {
                     href: changeDateUrl,
                     text: "Change",
-                    visuallyHiddenText: "date",
+                    visuallyHiddenText: "when would you like the person to complete their next online check in",
                     attributes: {
                         'data-qa': 'dateAction'
                     }
@@ -88,7 +88,7 @@
                 items: [ {
                     href: changeDateUrl,
                     text: "Change",
-                    visuallyHiddenText: "interval",
+                    visuallyHiddenText: "how often would you like the person to check in",
                     attributes: {
                         'data-qa': 'intervalAction'
                     }
@@ -102,7 +102,7 @@
                 items: [ {
                     href: contactPreUrl,
                     text: "Change",
-                    visuallyHiddenText: "preferredComs",
+                    visuallyHiddenText: "how does the person want us to send them a link",
                     attributes: {
                         'data-qa': 'preferredComsAction'
                     }
@@ -116,7 +116,7 @@
                 items: [ {
                     href: contactPreUrl,
                     text: "Change",
-                    visuallyHiddenText: "checkInMobile",
+                    visuallyHiddenText: "what is the person's mobile number",
                     attributes: {
                         'data-qa': 'checkInMobileAction'
                     }
@@ -130,7 +130,7 @@
                 items: [ {
                     href: contactPreUrl,
                     text: "Change",
-                    visuallyHiddenText: "checkInEmail",
+                    visuallyHiddenText: "what is the person's email address",
                     attributes: {
                         'data-qa': 'checkInEmailAction'
                     }


### PR DESCRIPTION
[ESUP-1952](https://dsdmoj.atlassian.net/browse/ESUP-1952)

Minor adjustment to the change links in the restart check ins summary page. Links now have contextual visually hidden text to help screen reader users.

[ESUP-1952]: https://dsdmoj.atlassian.net/browse/ESUP-1952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ