### PR TITLE
ESUP-2023 Wire in a username check alongside the PDU check

### DIFF
--- a/server/middleware/evaluateFeatureFlags.test.ts
+++ b/server/middleware/evaluateFeatureFlags.test.ts
@@ -106,6 +106,7 @@ describe('/middleware/evaluateFeatureFlags', () => {
 
       expect(getFlagsSpy).toHaveBeenCalledWith({
         email: 'test@example.com',
+        username: 'user-1',
         pduCodes: ['PDU001', 'PDU002'],
       })
     })
@@ -120,6 +121,7 @@ describe('/middleware/evaluateFeatureFlags', () => {
 
       expect(getFlagsSpy).toHaveBeenCalledWith({
         email: undefined,
+        username: 'user-1',
         pduCodes: [],
       })
     })

--- a/server/middleware/evaluateFeatureFlags.ts
+++ b/server/middleware/evaluateFeatureFlags.ts
@@ -7,7 +7,11 @@ export default function evaluateFeatureFlags(flagService: FlagService): RequestH
   return async (req, res: AppResponse, next) => {
     try {
       const pduCodes = (res.locals.user.probationDeliveryUnits || []).map(p => p.code)
-      const flags = await flagService.getFlags({ email: res.locals.user.email, pduCodes })
+      const flags = await flagService.getFlags({
+        email: res.locals.user.email,
+        username: res.locals.user.username,
+        pduCodes,
+      })
       if (flags) {
         res.locals.flags = flags
 

--- a/server/services/flagService.test.ts
+++ b/server/services/flagService.test.ts
@@ -1,8 +1,9 @@
 import { FliptEvaluationClient } from '@flipt-io/flipt-client'
 import * as Sentry from '@sentry/node'
-import { FlagService } from '.'
+import FlagService from './flagService'
 
 const email = 'test@example.com'
+const username = 'user-1'
 
 jest.mock('@sentry/node', () => ({
   getClient: jest.fn(() => ({})),
@@ -122,6 +123,31 @@ describe('FlagService', () => {
     expect(requests.filter((r: { flagKey: string }) => r.flagKey === 'enableNonCompliance')).toHaveLength(1)
     expect(requests.filter((r: { flagKey: string }) => r.flagKey === 'enableESupervisionCheckins')).toHaveLength(2)
   })
+  it('adds a username request for username-gated flags', async () => {
+    await service.getFlags({ email, username, pduCodes: ['PDU001', 'PDU002'] })
+    const requests = mockEvaluateBatch.mock.calls[0][0]
+
+    expect(requests).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          flagKey: 'enableESupervisionCheckins',
+          entityId: email,
+          context: { email, pduCode: 'PDU001' },
+        }),
+        expect.objectContaining({
+          flagKey: 'enableESupervisionCheckins',
+          entityId: email,
+          context: { email, pduCode: 'PDU002' },
+        }),
+        expect.objectContaining({
+          flagKey: 'enableESupervisionCheckins',
+          entityId: email,
+          context: { email, username },
+        }),
+      ]),
+    )
+    expect(requests.filter((r: { flagKey: string }) => r.flagKey === 'enableESupervisionCheckins')).toHaveLength(3)
+  })
   it('resolves a PDU-gated flag to true if any pduCode evaluation is enabled', async () => {
     mockEvaluateBatch.mockReturnValue({
       responses: [
@@ -132,6 +158,21 @@ describe('FlagService', () => {
       ],
     })
     expect(await service.getFlags({ email, pduCodes: ['PDU001', 'PDU002'] })).toStrictEqual({
+      enableDeliusClient: false,
+      enableNonCompliance: false,
+      enableESupervisionCheckins: true,
+    })
+  })
+  it('resolves the check-ins flag to true if the username evaluation is enabled', async () => {
+    mockEvaluateBatch.mockReturnValue({
+      responses: [
+        { booleanEvaluationResponse: { flagKey: 'enableDeliusClient', enabled: false } },
+        { booleanEvaluationResponse: { flagKey: 'enableNonCompliance', enabled: false } },
+        { booleanEvaluationResponse: { flagKey: 'enableESupervisionCheckins', enabled: true } },
+      ],
+    })
+
+    expect(await service.getFlags({ email, username, pduCodes: [] })).toStrictEqual({
       enableDeliusClient: false,
       enableNonCompliance: false,
       enableESupervisionCheckins: true,
@@ -162,7 +203,7 @@ describe('FlagService', () => {
     expect(result.enableDeliusClient).toBe(true)
     expect(result.enableNonCompliance).toBe(false)
   })
-  it('fails closed for PDU-gated flags when pduCodes is empty', async () => {
+  it('fails closed for check-ins flag when pduCodes is empty and username is not available', async () => {
     mockEvaluateBatch.mockReturnValue({
       responses: [
         { booleanEvaluationResponse: { flagKey: 'enableDeliusClient', enabled: false } },
@@ -174,6 +215,20 @@ describe('FlagService', () => {
 
     const requests = mockEvaluateBatch.mock.calls[0][0]
     expect(requests.filter((r: { flagKey: string }) => r.flagKey === 'enableESupervisionCheckins')).toHaveLength(0)
+    expect(result.enableESupervisionCheckins).toBe(false)
+  })
+  it('fails closed for check-ins flag when all access route evaluations are disabled', async () => {
+    mockEvaluateBatch.mockReturnValue({
+      responses: [
+        { booleanEvaluationResponse: { flagKey: 'enableDeliusClient', enabled: false } },
+        { booleanEvaluationResponse: { flagKey: 'enableNonCompliance', enabled: true } },
+        { booleanEvaluationResponse: { flagKey: 'enableESupervisionCheckins', enabled: false } },
+        { booleanEvaluationResponse: { flagKey: 'enableESupervisionCheckins', enabled: false } },
+      ],
+    })
+
+    const result = await service.getFlags({ email, username, pduCodes: ['PDU001'] })
+
     expect(result.enableESupervisionCheckins).toBe(false)
   })
   it('calls evaluateBatch with correct requests if context.email does not exist', async () => {
@@ -208,6 +263,22 @@ describe('FlagService', () => {
         expect.objectContaining({
           entityId: mixedCaseEmail.toLowerCase(),
           context: { email: mixedCaseEmail.toLowerCase() },
+        }),
+      ]),
+    )
+  })
+
+  it('normalises username to lowercase before sending to Flipt', async () => {
+    const mixedCaseUsername = 'User-ONE'
+
+    await service.getFlags({ username: mixedCaseUsername })
+
+    expect(mockEvaluateBatch).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          flagKey: 'enableESupervisionCheckins',
+          entityId: mixedCaseUsername.toLowerCase(),
+          context: { username: mixedCaseUsername.toLowerCase() },
         }),
       ]),
     )

--- a/server/services/flagService.ts
+++ b/server/services/flagService.ts
@@ -5,9 +5,16 @@ import { FeatureFlags } from '../data/model/featureFlags'
 import logger from '../../logger'
 
 const PDU_GATED_FLAGS = new Set(['enableESupervisionCheckins'])
+const USERNAME_GATED_FLAGS = new Set(['enableESupervisionCheckins'])
+
+interface FlagContext {
+  email?: string
+  username?: string
+  pduCodes?: string[]
+}
 
 export default class FlagService {
-  async getFlags(context: { email?: string; pduCodes?: string[] }): Promise<FeatureFlags> {
+  async getFlags(context: FlagContext): Promise<FeatureFlags> {
     const namespace = 'manage-people-on-probation-ui'
     const fliptEvaluationClient = await FliptEvaluationClient.init(namespace, {
       url: config.flipt.url,
@@ -24,21 +31,35 @@ export default class FlagService {
     })
 
     const pduCodes: string[] = context?.pduCodes ?? []
+    const email = context?.email?.toLowerCase()
+    const username = context?.username?.toLowerCase()
 
-    const buildRequest = (flag: string, pduCode?: string): EvaluationRequest => {
+    const buildRequest = (
+      flag: string,
+      additionalContext: { pduCode?: string; username?: string } = {},
+    ): EvaluationRequest => {
       return {
         flagKey: flag,
-        entityId: context?.email ? context.email.toLowerCase() || 'anonymous' : flag,
+        entityId: email || additionalContext.username || flag,
         context: {
-          ...(context?.email ? { email: context.email.toLowerCase() } : {}),
-          ...(pduCode ? { pduCode } : {}),
+          ...(email ? { email } : {}),
+          ...additionalContext,
         },
       }
     }
 
     const requests: EvaluationRequest[] = flagList.flatMap(flag => {
-      if (PDU_GATED_FLAGS.has(flag)) {
-        return pduCodes.map(pduCode => buildRequest(flag, pduCode))
+      const isPduGatedFlag = PDU_GATED_FLAGS.has(flag)
+      const isUsernameGatedFlag = USERNAME_GATED_FLAGS.has(flag)
+      const requestsForFlag: EvaluationRequest[] = []
+      if (isPduGatedFlag) {
+        requestsForFlag.push(...pduCodes.map(pduCode => buildRequest(flag, { pduCode })))
+      }
+      if (isUsernameGatedFlag && username) {
+        requestsForFlag.push(buildRequest(flag, { username }))
+      }
+      if (isPduGatedFlag || isUsernameGatedFlag) {
+        return requestsForFlag
       }
       return [buildRequest(flag)]
     })
@@ -51,7 +72,7 @@ export default class FlagService {
 
     for (const f of flagList) {
       const matching = responsesFor(flags.responses, f)
-      if (PDU_GATED_FLAGS.has(f)) {
+      if (PDU_GATED_FLAGS.has(f) || USERNAME_GATED_FLAGS.has(f)) {
         featureFlags[f] = matching.some(r => r.booleanEvaluationResponse?.enabled === true)
       } else if (matching.length === 1) {
         featureFlags[f] = matching[0].booleanEvaluationResponse.enabled === true


### PR DESCRIPTION
Adds a username-based allowlist as an additional access route for the enableESupervisionCheckins feature flag, evaluated alongside the existing PDU check. A practitioner now gets access to e-supervision check-ins if they are in an allowed PDU or their username is on the allowlist.

- FlagService.getFlags now accepts an optional username in its context (new FlagContext interface).
- For username-gated flags, an additional Flipt evaluation request is sent with context: { username }. The username is lowercased before sending, mirroring the existing email normalisation.
- Flags in PDU_GATED_FLAGS / USERNAME_GATED_FLAGS are resolved by OR-ing every route's evaluation: the flag is true if any PDU code or the username evaluation returns enabled. Behaviour still fails closed when no route is enabled or no context is available.
- evaluateFeatureFlags middleware now passes res.locals.user.username (populated from HMPPS Auth) into getFlags.

Testing

- Added unit tests covering: username request fan-out, resolving true on username match, fail-closed when all routes are disabled, and lowercase normalisation of the username.
- All flagService / evaluateFeatureFlags tests pass; typecheck and lint clean.