### PR TITLE
[ESUP-1984 & ESUP-2005] Remove ESUP feature flags

### DIFF
--- a/server/controllers/check-ins.test.ts
+++ b/server/controllers/check-ins.test.ts
@@ -209,7 +209,6 @@ describe('checkInsController', () => {
 
         const req = baseReq()
         const { id } = req.params as Record<string, string>
-        res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
         await controllers.checkIns.getEligibilityDeniedPage(hmppsAuthClient)(req, res)
 
         expect(renderSpy).toHaveBeenCalledWith('pages/check-in/eligibility-denied.njk', {
@@ -224,7 +223,6 @@ describe('checkInsController', () => {
       it('returns 404 when CRN is invalid', async () => {
         mockIsValidCrn.mockReturnValue(false)
         mockIsValidUUID.mockReturnValue(true)
-        res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
 
         const req = baseReq()
         await controllers.checkIns.getEligibilityDeniedPage(hmppsAuthClient)(req, res)
@@ -241,7 +239,6 @@ describe('checkInsController', () => {
 
         const req = baseReq()
         const { id } = req.params as Record<string, string>
-        res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
         await controllers.checkIns.getFullEligibilityPage(hmppsAuthClient)(req, res)
 
         expect(renderSpy).toHaveBeenCalledWith('pages/check-in/eligibility-full.njk', {
@@ -258,7 +255,6 @@ describe('checkInsController', () => {
         mockIsValidUUID.mockReturnValue(true)
 
         const req = baseReq()
-        res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
         await controllers.checkIns.getFullEligibilityPage(hmppsAuthClient)(req, res)
 
         expect(mockRenderError).toHaveBeenCalledWith(404)
@@ -272,7 +268,6 @@ describe('checkInsController', () => {
         mockIsValidUUID.mockReturnValue(true)
 
         const req = baseReq()
-        res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
         const { id } = req.params as Record<string, string>
         await controllers.checkIns.getSPOApprovalPage(hmppsAuthClient)(req, res)
 
@@ -291,7 +286,6 @@ describe('checkInsController', () => {
         mockIsValidUUID.mockReturnValue(true)
 
         const req = baseReq()
-        res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
         await controllers.checkIns.getSPOApprovalPage(hmppsAuthClient)(req, res)
 
         expect(mockRenderError).toHaveBeenCalledWith(404)
@@ -301,8 +295,6 @@ describe('checkInsController', () => {
       it('sets isApproved true when SPO approval is selected', async () => {
         mockIsValidCrn.mockReturnValue(true)
         mockIsValidUUID.mockReturnValue(true)
-
-        res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
 
         const req = baseReq()
         req.session.data = {
@@ -334,7 +326,6 @@ describe('checkInsController', () => {
         mockIsValidUUID.mockReturnValue(true)
 
         const req = baseReq()
-        res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
         await controllers.checkIns.postSPOApprovalPage(hmppsAuthClient)(req, res)
 
         expect(redirectSpy).toHaveBeenCalledWith(`/case/${crn}/appointments/${uuid}/check-in/rationale`)
@@ -345,7 +336,6 @@ describe('checkInsController', () => {
         mockIsValidUUID.mockReturnValue(true)
 
         const req = baseReq()
-        res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
         await controllers.checkIns.postSPOApprovalPage(hmppsAuthClient)(req, res)
 
         expect(mockRenderError).toHaveBeenCalledWith(404)
@@ -357,23 +347,10 @@ describe('checkInsController', () => {
         mockIsValidUUID.mockReturnValue(false)
 
         const req = baseReq()
-        res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
         await controllers.checkIns.postSPOApprovalPage(hmppsAuthClient)(req, res)
 
         expect(mockRenderError).toHaveBeenCalledWith(404)
         expect(mockMiddlewareFn).toHaveBeenCalledWith(req, res)
-      })
-
-      it('redirects SPO approval to date-frequency when rationale flag is off', async () => {
-        mockIsValidCrn.mockReturnValue(true)
-        mockIsValidUUID.mockReturnValue(true)
-
-        const req = baseReq()
-        res.locals.flags = { enableEsupervisionRationale: false }
-
-        await controllers.checkIns.postSPOApprovalPage(hmppsAuthClient)(req, res)
-
-        expect(redirectSpy).toHaveBeenCalledWith(`/case/${crn}/appointments/${uuid}/check-in/date-frequency`)
       })
     })
 
@@ -457,7 +434,6 @@ describe('checkInsController', () => {
         mockIsValidUUID.mockReturnValue(true)
 
         const req = baseReq()
-        res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
         const { id } = req.params as Record<string, string>
 
         await controllers.checkIns.postFullEligibilityPage(hmppsAuthClient)(req, res)
@@ -469,7 +445,6 @@ describe('checkInsController', () => {
       it('redirects full eligibility to SPO approval when replacing F2F', async () => {
         mockIsValidCrn.mockReturnValue(true)
         mockIsValidUUID.mockReturnValue(true)
-        res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
 
         const req = baseReq()
         req.session.data = {
@@ -494,25 +469,12 @@ describe('checkInsController', () => {
         mockIsValidUUID.mockReturnValue(true)
 
         const req = baseReq()
-        res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
         const { id } = req.params as Record<string, string>
 
         await controllers.checkIns.postSupplementaryEligibilityPage(hmppsAuthClient)(req, res)
 
         expect(mockSetDataValue).toHaveBeenCalledWith(req.session.data, ['esupervision', crn, id, 'checkins', 'id'], id)
         expect(redirectSpy).toHaveBeenCalledWith(`/case/${crn}/appointments/${id}/check-in/rationale`)
-      })
-
-      it('redirects supplementary eligibility to date-frequency when rationale flag is off', async () => {
-        mockIsValidCrn.mockReturnValue(true)
-        mockIsValidUUID.mockReturnValue(true)
-
-        const req = baseReq()
-        res.locals.flags = { enableEsupervisionRationale: false }
-
-        await controllers.checkIns.postSupplementaryEligibilityPage(hmppsAuthClient)(req, res)
-
-        expect(redirectSpy).toHaveBeenCalledWith(`/case/${crn}/appointments/${uuid}/check-in/date-frequency`)
       })
     })
 
@@ -536,7 +498,6 @@ describe('checkInsController', () => {
       mockIsValidUUID.mockReturnValue(true)
 
       const req = baseReq()
-      res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
 
       const { id } = req.params as Record<string, string>
       await controllers.checkIns.getRationalePage(hmppsAuthClient)(req, res)
@@ -561,24 +522,11 @@ describe('checkInsController', () => {
       expect(mockMiddlewareFn).toHaveBeenCalledWith(req, res)
     })
 
-    it('redirects rationale page to case overview when rationale flag is off', async () => {
-      mockIsValidCrn.mockReturnValue(true)
-      mockIsValidUUID.mockReturnValue(true)
-      const req = baseReq()
-
-      res.locals.flags = { enableEsupervisionRationale: false }
-
-      await controllers.checkIns.getRationalePage(hmppsAuthClient)(req, res)
-
-      expect(redirectSpy).toHaveBeenCalledWith(`/case/${crn}`)
-    })
-
     it('uses SPO approval as rationale backLink for REPLACE_F2F', async () => {
       mockIsValidCrn.mockReturnValue(true)
       mockIsValidUUID.mockReturnValue(true)
 
       const req = baseReq()
-      res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
 
       req.session.data = {
         esupervision: {
@@ -607,7 +555,6 @@ describe('checkInsController', () => {
 
       const req = baseReq()
       req.query = { cya: 'true' }
-      res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
 
       await controllers.checkIns.getRationalePage(hmppsAuthClient)(req, res)
 
@@ -663,7 +610,6 @@ describe('checkInsController', () => {
       mockIsValidUUID.mockReturnValue(true)
 
       const req = baseReq()
-      res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
       await controllers.checkIns.getDateFrequencyPage(hmppsAuthClient)(req, res)
 
       expect(renderSpy).toHaveBeenCalledWith('pages/check-in/date-frequency.njk', {
@@ -684,7 +630,6 @@ describe('checkInsController', () => {
       mockIsValidUUID.mockReturnValue(true)
 
       const req = baseReq()
-      res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
       await controllers.checkIns.getDateFrequencyPage(hmppsAuthClient)(req, res)
 
       expect(renderSpy).toHaveBeenCalledWith('pages/check-in/date-frequency.njk', {
@@ -724,7 +669,6 @@ describe('checkInsController', () => {
 
       const req = baseReq()
       req.query = { cya: 'true' }
-      res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
 
       await controllers.checkIns.getDateFrequencyPage(hmppsAuthClient)(req, res)
 
@@ -733,52 +677,6 @@ describe('checkInsController', () => {
         expect.objectContaining({
           cya: true,
           backLink: `/case/${crn}/appointments/${uuid}/check-in/checkin-summary`,
-        }),
-      )
-    })
-
-    it('uses SPO approval as date-frequency backLink when rationale is off and replacing F2F', async () => {
-      mockIsValidCrn.mockReturnValue(true)
-      mockIsValidUUID.mockReturnValue(true)
-
-      const req = baseReq()
-      res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: false }
-
-      req.session.data = {
-        esupervision: {
-          [crn]: {
-            [uuid]: {
-              checkins: {
-                eligibilityChoice: 'REPLACE_F2F',
-              },
-            },
-          },
-        },
-      }
-
-      await controllers.checkIns.getDateFrequencyPage(hmppsAuthClient)(req, res)
-
-      expect(renderSpy).toHaveBeenCalledWith(
-        'pages/check-in/date-frequency.njk',
-        expect.objectContaining({
-          backLink: `/case/${crn}/appointments/${uuid}/check-in/spo-approval`,
-        }),
-      )
-    })
-
-    it('uses supplementary eligibility as date-frequency backLink when rationale is off by default', async () => {
-      mockIsValidCrn.mockReturnValue(true)
-      mockIsValidUUID.mockReturnValue(true)
-
-      const req = baseReq()
-      res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: false }
-
-      await controllers.checkIns.getDateFrequencyPage(hmppsAuthClient)(req, res)
-
-      expect(renderSpy).toHaveBeenCalledWith(
-        'pages/check-in/date-frequency.njk',
-        expect.objectContaining({
-          backLink: `/case/${crn}/appointments/${uuid}/check-in/supplementary-eligibility`,
         }),
       )
     })
@@ -1318,7 +1216,6 @@ describe('checkInsController', () => {
     it('renders summary with transformed userDetails when CRN and id are valid', async () => {
       mockIsValidCrn.mockReturnValue(true)
       mockIsValidUUID.mockReturnValue(true)
-      res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: true }
       const req = httpMocks.createRequest({
         params: { crn, id: uuid },
         session: { data: baseSessionData },
@@ -1341,31 +1238,6 @@ describe('checkInsController', () => {
         }),
       )
       expect(mockRenderError).not.toHaveBeenCalled()
-    })
-
-    it('renders summary with rationale hidden when rationale flag is disabled', async () => {
-      mockIsValidCrn.mockReturnValue(true)
-      mockIsValidUUID.mockReturnValue(true)
-      res.locals.flags = { enableEsupervisionEligibility: true, enableEsupervisionRationale: false }
-
-      const req = httpMocks.createRequest({
-        params: { crn, id: uuid },
-        session: { data: baseSessionData },
-      })
-
-      await controllers.checkIns.getCheckinSummaryPage(hmppsAuthClient)(req, res)
-
-      expect(renderSpy).toHaveBeenCalledWith(
-        'pages/check-in/checkin-summary.njk',
-        expect.objectContaining({
-          crn,
-          id: uuid,
-          isRationaleEnabled: false,
-          userDetails: expect.objectContaining({
-            rationale: 'Unlikely to reoffend',
-          }),
-        }),
-      )
     })
 
     it('returns 404 when CRN is invalid', async () => {

--- a/server/controllers/check-ins.ts
+++ b/server/controllers/check-ins.ts
@@ -221,11 +221,7 @@ const checkInsController: Controller<typeof routes, void> = {
       if (eligibilityChoice === 'REPLACE_F2F') {
         return res.redirect(`/case/${crn}/appointments/${id}/check-in/spo-approval`)
       }
-      const isRationaleEnabled = res.locals.flags?.enableEsupervisionRationale === true
-      if (isRationaleEnabled) {
-        return res.redirect(`/case/${crn}/appointments/${id}/check-in/rationale`)
-      }
-      return res.redirect(`/case/${crn}/appointments/${id}/check-in/date-frequency`)
+      return res.redirect(`/case/${crn}/appointments/${id}/check-in/rationale`)
     }
   },
 
@@ -250,11 +246,7 @@ const checkInsController: Controller<typeof routes, void> = {
       }
       setDataValue(data, ['esupervision', crn, id, 'checkins', 'id'], id)
       setDataValue(data, ['esupervision', crn, id, 'checkins', 'eligibilityChoice'], 'SUPPLEMENT_F2F')
-      const isRationaleEnabled = res.locals.flags?.enableEsupervisionRationale === true
-      if (isRationaleEnabled) {
-        return res.redirect(`/case/${crn}/appointments/${id}/check-in/rationale`)
-      }
-      return res.redirect(`/case/${crn}/appointments/${id}/check-in/date-frequency`)
+      return res.redirect(`/case/${crn}/appointments/${id}/check-in/rationale`)
     }
   },
 
@@ -289,11 +281,7 @@ const checkInsController: Controller<typeof routes, void> = {
       if (approval) {
         setDataValue(data, ['esupervision', crn, id, 'checkins', 'eligibilitySPOApproval'], approval)
       }
-      const isRationaleEnabled = res.locals.flags?.enableEsupervisionRationale === true
-      if (isRationaleEnabled) {
-        return res.redirect(`/case/${crn}/appointments/${id}/check-in/rationale`)
-      }
-      return res.redirect(`/case/${crn}/appointments/${id}/check-in/date-frequency`)
+      return res.redirect(`/case/${crn}/appointments/${id}/check-in/rationale`)
     }
   },
 
@@ -301,11 +289,7 @@ const checkInsController: Controller<typeof routes, void> = {
     return async (req, res) => {
       const { crn, id } = req.params as Record<string, string>
       if (!isValidCrn(crn) || !isValidUUID(id)) return renderError(404)(req, res)
-      const isRationaleEnabled = res.locals.flags?.enableEsupervisionRationale === true
 
-      if (!isRationaleEnabled) {
-        return res.redirect(`/case/${crn}`)
-      }
       const cya = req.query.cya === 'true'
       const eligibility = req.session.data?.esupervision?.[crn]?.[id]?.checkins?.eligibility || []
       const eligibilityArray = Array.isArray(eligibility) ? eligibility : [eligibility]
@@ -350,21 +334,7 @@ const checkInsController: Controller<typeof routes, void> = {
       }
       const cya = req.query.cya === 'true'
       let backLink: string
-      const isRationaleEnabled = res.locals.flags?.enableEsupervisionRationale === true
-      if (!isRationaleEnabled) {
-        const eligibility = req.session.data?.esupervision?.[crn]?.[id]?.checkins?.eligibility || []
-        const eligibilityArray = Array.isArray(eligibility) ? eligibility : [eligibility]
-        const eligibilityChoice = req.session.data?.esupervision?.[crn]?.[id]?.checkins?.eligibilityChoice
-        if (cya) {
-          backLink = `/case/${crn}/appointments/${id}/check-in/checkin-summary`
-        } else if (eligibilityChoice === 'REPLACE_F2F') {
-          backLink = `/case/${crn}/appointments/${id}/check-in/spo-approval`
-        } else if (eligibilityArray.includes('eligibility-none')) {
-          backLink = `/case/${crn}/appointments/${id}/check-in/full-eligibility`
-        } else {
-          backLink = `/case/${crn}/appointments/${id}/check-in/supplementary-eligibility`
-        }
-      } else if (cya) {
+      if (cya) {
         backLink = `/case/${crn}/appointments/${id}/check-in/checkin-summary`
       } else {
         backLink = `/case/${crn}/appointments/${id}/check-in/rationale`
@@ -792,9 +762,8 @@ const checkInsController: Controller<typeof routes, void> = {
         photoUploadOption:
           savedUserDetails.photoUploadOption === 'TAKE_A_PIC' ? 'Take a photo using this device' : 'Upload a photo',
       }
-      const isRationaleEnabled = res.locals.flags?.enableEsupervisionRationale === true
       await sendAuditMessage(res, 'VIEW_MAS_CHECK_IN_SUMMARY', crn, SubjectType.CRN)
-      return res.render('pages/check-in/checkin-summary.njk', { crn, id, userDetails, isRationaleEnabled })
+      return res.render('pages/check-in/checkin-summary.njk', { crn, id, userDetails })
     }
   },
 

--- a/server/data/model/featureFlags.ts
+++ b/server/data/model/featureFlags.ts
@@ -21,7 +21,5 @@ export class FeatureFlags {
   enableCaseloadV2?: boolean = undefined
   enableEnforcementContacts?: boolean = undefined
   enableBreachOrRecallAndSendLetterAction?: boolean = undefined
-  enableEsupervisionEligibility?: boolean = undefined
-  enableEsupervisionRationale?: boolean = undefined
   enableSessionCacheLogging?: boolean = undefined
 }

--- a/server/data/model/featureFlags.ts
+++ b/server/data/model/featureFlags.ts
@@ -15,7 +15,6 @@ export class FeatureFlags {
   enableHomePageOutcomesWithFilter?: boolean = undefined
   enableSensitivityRemoved?: boolean = undefined
   enableMyEnforcementActionsOverview?: boolean = undefined
-  enableShowMatchWithConcern?: boolean = undefined
   enableEMDISentencesShowGPSData?: boolean = undefined
   enableEMDIOverviewShowGPSData?: boolean = undefined
   enableCaseloadV2?: boolean = undefined

--- a/server/middleware/postCheckInDetails.test.ts
+++ b/server/middleware/postCheckInDetails.test.ts
@@ -57,7 +57,6 @@ describe('postCheckInDetails', () => {
     const res: any = {
       locals: {
         user: overrides?.user ?? { username },
-        flags: { enableEsupervisionEligibility: true, enableEsupervisionRationale: true },
         case: { ...baseCase, ...(overrides?.caseOverrides ?? {}) },
       },
       status: jest.fn().mockReturnThis(),
@@ -195,24 +194,5 @@ describe('postCheckInDetails', () => {
     expect(res.status).not.toHaveBeenCalled()
     expect(res.json).not.toHaveBeenCalled()
     expect(getProfilePhotoUploadLocation).not.toHaveBeenCalled()
-  })
-  it('does not send rationale when rationale flag is disabled', async () => {
-    const { req, res } = buildReqRes()
-    res.locals.flags.enableEsupervisionRationale = false
-
-    jest.spyOn(MasApiClient.prototype, 'getProbationPractitioner').mockResolvedValue({ username: 'pp-user' } as any)
-
-    const setup = { uuid: setupUuid }
-    const postOffenderSetup = jest
-      .spyOn(ESupervisionClient.prototype, 'postOffenderSetup')
-      .mockResolvedValue(setup as any)
-
-    jest
-      .spyOn(ESupervisionClient.prototype, 'getProfilePhotoUploadLocation')
-      .mockResolvedValue({ locationInfo: { url: 'http://upload', method: 'PUT' } } as any)
-
-    await postCheckInDetails(hmppsAuthClient)(req, res)
-
-    expect(postOffenderSetup.mock.calls[0][0]).not.toHaveProperty('rationale')
   })
 })

--- a/server/middleware/postCheckInDetails.ts
+++ b/server/middleware/postCheckInDetails.ts
@@ -11,8 +11,6 @@ export const postCheckInDetails = (
   hmppsAuthClient: HmppsAuthClient,
 ): Route<Promise<{ setup: OffenderSetup; uploadLocation: UploadLocationResponse }>> => {
   return async (req, res) => {
-    const isEligibilityEnabled = res.locals.flags?.enableEsupervisionEligibility === true
-    const isRationaleEnabled = res.locals.flags?.enableEsupervisionRationale === true
     const { crn, id } = req.params as Record<string, string>
     // The browser sends a base64-encoded SHA-256 digest (see assets/js/photo.js sha256Base64).
     // S3 enforces the matching x-amz-checksum-sha256 on the PUT, so we only guard presence here.
@@ -43,12 +41,8 @@ export const postCheckInDetails = (
       checkinInterval: savedUserDetails.interval,
       startedAt: new Date().toISOString(),
       contactPreference: savedUserDetails.preferredComs,
-      ...(isEligibilityEnabled && {
-        eligibilityChoice: savedUserDetails.eligibilityChoice,
-      }),
-      ...(isRationaleEnabled && {
-        rationale: savedUserDetails.rationale,
-      }),
+      eligibilityChoice: savedUserDetails.eligibilityChoice,
+      rationale: savedUserDetails.rationale,
     }
     logger.info('Checkin Registration started')
     try {

--- a/server/middleware/validation/eSuperVision.ts
+++ b/server/middleware/validation/eSuperVision.ts
@@ -126,24 +126,17 @@ const eSuperVision: Route<void> = (req, res, next) => {
   const validateDateFrequency = () => {
     if (baseUrl.includes(`/case/${crn}/appointments/${id}/check-in/date-frequency`)) {
       render = `pages/check-in/date-frequency`
-      const eligibility = req.session.data?.esupervision?.[crn]?.[id]?.checkins?.eligibility || []
-      const eligibilityArray = Array.isArray(eligibility) ? eligibility : [eligibility]
-      const eligibilityChoice = req.session.data?.esupervision?.[crn]?.[id]?.checkins?.eligibilityChoice
+
       let backUrl: string
-      const isRationaleEnabled = res.locals.flags?.enableEsupervisionRationale === true
 
       if (cya) {
         backUrl = `/case/${crn}/appointments/${id}/check-in/checkin-summary`
-      } else if (isRationaleEnabled) {
-        backUrl = `/case/${crn}/appointments/${id}/check-in/rationale`
-      } else if (eligibilityChoice === 'REPLACE_F2F') {
-        backUrl = `/case/${crn}/appointments/${id}/check-in/spo-approval`
-      } else if (eligibilityArray.includes('eligibility-none')) {
-        backUrl = `/case/${crn}/appointments/${id}/check-in/full-eligibility`
       } else {
-        backUrl = `/case/${crn}/appointments/${id}/check-in/supplementary-eligibility`
+        backUrl = `/case/${crn}/appointments/${id}/check-in/rationale`
       }
+
       res.locals.backLink = backUrl
+
       errorMessages = validateWithSpec(
         req,
         eSuperVisionValidation({

--- a/server/views/pages/check-in/checkin-summary.njk
+++ b/server/views/pages/check-in/checkin-summary.njk
@@ -91,7 +91,6 @@
     {%  block pageContent %}
     {% set summaryRows = [] %}
 
-    {% if isRationaleEnabled %}
     {% set _ = summaryRows.push({
         key: {
         html: rationaleLabel
@@ -110,7 +109,6 @@
         }]
         }
     }) %}
-    {% endif %}
 
     {% set _ = summaryRows.push(
     {

--- a/server/views/pages/check-in/review/identity.njk
+++ b/server/views/pages/check-in/review/identity.njk
@@ -93,7 +93,6 @@
         </dl>
 
         <form method="post" autocomplete="off" action="{{ paths.current  }}">
-            {% if flags.enableShowMatchWithConcern === true %}
                 {{ govukRadios({
                     fieldset: {
                         legend: {
@@ -124,31 +123,6 @@
                         }
                     ]
                 } | decorateFormAttributes(['esupervision', crn, id, 'checkins', 'manualIdCheck'])) }}
-            {% else %}
-                {{ govukRadios({
-                    fieldset: {
-                        legend: {
-                            text: 'Is the person in the image from the check in ' + checkIn.personalDetails.name.forename + '?',
-                            classes: "govuk-label--m govuk-!-font-weight-bold"
-                        }
-                    },
-                    formGroup: {
-                        attributes: {
-                            'data-qa': 'confirmIdentity'
-                        }
-                    },
-                    items: [
-                        {
-                            value: "MATCH",
-                            text: "Yes"
-                        },
-                        {
-                            value: "NO_MATCH",
-                            text: "No"
-                        }
-                    ]
-                } | decorateFormAttributes(['esupervision', crn, id, 'checkins', 'manualIdCheck'])) }}
-            {% endif %}
 
             <div class="govuk-button-group">
                 {{ govukButton({

--- a/server/views/pages/check-in/view.njk
+++ b/server/views/pages/check-in/view.njk
@@ -168,7 +168,7 @@
                 <dt class="govuk-summary-list__key">{{"System ID and liveness check result" if checkIn.livenessEnabled else "System ID check result"}}</dt>
                 <dd class="govuk-summary-list__value">{{"Pass" if systemIdCheckPass else "Fail"}}</dd>
             </div>
-            {% if flags.enableShowMatchWithConcern === true and checkIn.manualIdCheck == "NO_MATCH" %}
+            {% if checkIn.manualIdCheck == "NO_MATCH" %}
                 <div class="govuk-summary-list__row">
                     <dt class="govuk-summary-list__key">Image of {{ checkIn.personalDetails.name.forename }}</dt>
                     <dd class="govuk-summary-list__value">
@@ -180,7 +180,7 @@
                     </dd>
                 </div>
             {% endif %}
-            {% if flags.enableShowMatchWithConcern === true and checkIn.manualIdCheck != "MATCH" %}
+            {% if checkIn.manualIdCheck != "MATCH" %}
                 <div class="govuk-summary-list__row">
                     <dt class="govuk-summary-list__key">Image from check in</dt>
                     <dd class="govuk-summary-list__value">

--- a/wiremock/mappings/flipt.json
+++ b/wiremock/mappings/flipt.json
@@ -209,28 +209,6 @@
               "updatedAt": "2026-06-12T12:00:00.000000Z",
               "rules": [],
               "rollouts": []
-            },
-            {
-              "key": "enableEsupervisionEligibility",
-              "name": "enableEsupervisionEligibility",
-              "description": "",
-              "enabled": true,
-              "type": "BOOLEAN_FLAG_TYPE",
-              "createdAt": "2026-06-17T12:00:00.000000Z",
-              "updatedAt": "2026-06-17T12:00:00.000000Z",
-              "rules": [],
-              "rollouts": []
-            },
-            {
-              "key": "enableEsupervisionRationale",
-              "name": "enableEsupervisionRationale",
-              "description": "",
-              "enabled": true,
-              "type": "BOOLEAN_FLAG_TYPE",
-              "createdAt": "2026-06-17T12:00:00.000000Z",
-              "updatedAt": "2026-06-17T12:00:00.000000Z",
-              "rules": [],
-              "rollouts": []
             }
           ]
         }

--- a/wiremock/mappings/flipt.json
+++ b/wiremock/mappings/flipt.json
@@ -156,17 +156,6 @@
               "rollouts": []
             },
             {
-              "key": "enableShowMatchWithConcern",
-              "name": "enableShowMatchWithConcern",
-              "description": "",
-              "enabled": true,
-              "type": "BOOLEAN_FLAG_TYPE",
-              "createdAt": "2026-05-18T12:00:00.000000Z",
-              "updatedAt": "2026-05-18T12:00:00.000000Z",
-              "rules": [],
-              "rollouts": []
-            },
-            {
               "key": "enableEMDISentencesShowGPSData",
               "name": "enableEMDISentencesShowGPSData",
               "description": "",

--- a/wiremock/stubs/flags.ts
+++ b/wiremock/stubs/flags.ts
@@ -318,38 +318,6 @@ const stubDisableESupervisionCheckins = (): SuperAgentRequest =>
     },
   })
 
-const stubEnableShowMatchWithConcern = (): SuperAgentRequest =>
-  superagent.post('http://localhost:9091/__admin/mappings').send({
-    request: {
-      urlPathPattern: '/flipt/internal/v1/evaluation/snapshot/namespace/manage-people-on-probation-ui',
-      method: 'GET',
-    },
-    response: {
-      status: 200,
-      jsonBody: {
-        namespace: {
-          key: 'manage-people-on-probation-ui',
-        },
-        flags: [
-          {
-            key: 'enableShowMatchWithConcern',
-            name: 'enableShowMatchWithConcern',
-            description: '',
-            enabled: true,
-            type: 'BOOLEAN_FLAG_TYPE',
-            createdAt: '2026-05-18T12:00:00.000000Z',
-            updatedAt: '2026-05-18T12:00:00.000000Z',
-            rules: [],
-            rollouts: [],
-          },
-        ],
-      },
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    },
-  })
-
 const stubDisableEMDIOverviewShowGPSData = (): SuperAgentRequest =>
   superagent.post('http://localhost:9091/__admin/mappings').send({
     request: {
@@ -458,7 +426,6 @@ export default {
   stubEnableDeepLinks,
   stubDisableESupervisionCheckins,
   stubDisableHomePageOutcome,
-  stubEnableShowMatchWithConcern,
   stubDisableEMDIOverviewShowGPSData,
   stubDisableEnforcementContacts,
   stubFeatureFlag,

--- a/wiremock/stubs/flags.ts
+++ b/wiremock/stubs/flags.ts
@@ -449,70 +449,6 @@ const stubFeatureFlag = ({ key, enabled }: { key: string; enabled: boolean }): S
     },
   })
 
-const stubEnableEsupervisionEligibility = (): SuperAgentRequest =>
-  superagent.post('http://localhost:9091/__admin/mappings').send({
-    request: {
-      urlPathPattern: '/flipt/internal/v1/evaluation/snapshot/namespace/manage-people-on-probation-ui',
-      method: 'GET',
-    },
-    response: {
-      status: 200,
-      jsonBody: {
-        namespace: {
-          key: 'manage-people-on-probation-ui',
-        },
-        flags: [
-          {
-            key: 'enableEsupervisionEligibility',
-            name: 'enableEsupervisionEligibility',
-            description: '',
-            enabled: true,
-            type: 'BOOLEAN_FLAG_TYPE',
-            createdAt: '2026-06-17T12:00:00.000000Z',
-            updatedAt: '2026-06-17T12:00:00.000000Z',
-            rules: [],
-            rollouts: [],
-          },
-        ],
-      },
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    },
-  })
-
-const stubEnableEsupervisionRationale = (): SuperAgentRequest =>
-  superagent.post('http://localhost:9091/__admin/mappings').send({
-    request: {
-      urlPathPattern: '/flipt/internal/v1/evaluation/snapshot/namespace/manage-people-on-probation-ui',
-      method: 'GET',
-    },
-    response: {
-      status: 200,
-      jsonBody: {
-        namespace: {
-          key: 'manage-people-on-probation-ui',
-        },
-        flags: [
-          {
-            key: 'enableEsupervisionRationale',
-            name: 'enableEsupervisionRationale',
-            description: '',
-            enabled: true,
-            type: 'BOOLEAN_FLAG_TYPE',
-            createdAt: '2026-06-17T12:00:00.000000Z',
-            updatedAt: '2026-06-17T12:00:00.000000Z',
-            rules: [],
-            rollouts: [],
-          },
-        ],
-      },
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    },
-  })
-
 export default {
   stubEnableESuperVision,
   stubDisableSmsReminders,
@@ -526,6 +462,4 @@ export default {
   stubDisableEMDIOverviewShowGPSData,
   stubDisableEnforcementContacts,
   stubFeatureFlag,
-  stubEnableEsupervisionEligibility,
-  stubEnableEsupervisionRationale,
 }


### PR DESCRIPTION
[ESUP-1984](https://dsdmoj.atlassian.net/browse/ESUP-1984)
[ESUP-2005](https://dsdmoj.atlassian.net/browse/ESUP-2005)

The following flags have been removed from the codebase:

- enableEsupervisionEligibility
- enableEsupervisionRationale
- enableShowMatchWithConcern


The features are all deployed to prod and are enabled in Flipt prod so this now safely removes the code checking for them.
Once this branch has been deployed we will be able to remove them from each flipt environments too.

[ESUP-1984]: https://dsdmoj.atlassian.net/browse/ESUP-1984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ESUP-2005]: https://dsdmoj.atlassian.net/browse/ESUP-2005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ