### PR TITLE
MAN-2955: rename Appointments to All appointment, add feature flag and adds a new SPARKS filter

### DIFF
--- a/server/data/model/featureFlags.ts
+++ b/server/data/model/featureFlags.ts
@@ -22,4 +22,5 @@ export class FeatureFlags {
   enableSessionCacheLogging?: boolean = undefined
   enableESUPCheckinNewStop?: boolean = undefined
   enableESUPCheckinNewQuestions?: boolean = undefined
+  enableSparksFilter?: boolean = undefined
 }

--- a/server/middleware/filterActivityLog.test.ts
+++ b/server/middleware/filterActivityLog.test.ts
@@ -247,6 +247,29 @@ describe('/middleware/filterActivityLog()', () => {
     })
   })
 
+  describe('a session category value is not present in the current options (e.g. flag turned off after selecting SPARKS)', () => {
+    const req = getRequest({
+      submit: true,
+      keywords: '',
+      dateFrom: '',
+      dateTo: '',
+      compliance: 'complied',
+      category: ['appointments with sparks activity', 'appointments'],
+      hideContact: 'hide NDelius system generated contacts',
+    })
+    beforeEach(() => {
+      filterActivityLog(req, res, nextSpy)
+    })
+    it('should skip the unknown category instead of throwing', () => {
+      expect(res.locals.filters.selectedFilterItems.category).toEqual([
+        {
+          text: 'Appointments',
+          href: `/case/${crn}/activity-log?clearFilterKey=category&clearFilterValue=appointments`,
+        },
+      ])
+    })
+  })
+
   describe('All filters are completed', () => {
     const req = getRequest()
     req.session.activityLogFilters = {

--- a/server/middleware/filterActivityLog.test.ts
+++ b/server/middleware/filterActivityLog.test.ts
@@ -202,6 +202,42 @@ describe('/middleware/filterActivityLog()', () => {
     })
   })
 
+  describe('enableSparksFilter feature flag is enabled', () => {
+    const flaggedRes = {
+      locals: {
+        user: { username: 'user-1' },
+        flags: { enableSparksFilter: true },
+      },
+      redirect: jest.fn().mockReturnThis(),
+    } as unknown as AppResponse
+    const req = getRequest({
+      submit: true,
+      keywords: '',
+      dateFrom: '',
+      dateTo: '',
+      compliance: 'complied',
+      category: 'appointments',
+      hideContact: 'hide NDelius system generated contacts',
+    })
+    beforeEach(() => {
+      filterActivityLog(req, flaggedRes, nextSpy)
+    })
+    it('should rename the appointments category to "All appointments" in the checkbox options', () => {
+      const appointmentsOption = flaggedRes.locals.filters.categoryOptions.find(
+        option => option.value === 'appointments',
+      )
+      expect(appointmentsOption.text).toEqual('All appointments')
+    })
+    it('should rename the appointments category to "All appointments" in the selected filter tag', () => {
+      expect(flaggedRes.locals.filters.selectedFilterItems.category).toEqual([
+        {
+          text: 'All appointments',
+          href: `/case/${crn}/activity-log?clearFilterKey=category&clearFilterValue=appointments`,
+        },
+      ])
+    })
+  })
+
   describe('All filters are completed', () => {
     const req = getRequest()
     req.session.activityLogFilters = {

--- a/server/middleware/filterActivityLog.test.ts
+++ b/server/middleware/filterActivityLog.test.ts
@@ -228,6 +228,15 @@ describe('/middleware/filterActivityLog()', () => {
       )
       expect(appointmentsOption.text).toEqual('All appointments')
     })
+    it('should add the SPARKS category directly after "All appointments" in the checkbox options', () => {
+      const { categoryOptions } = flaggedRes.locals.filters
+      const appointmentsIndex = categoryOptions.findIndex(option => option.value === 'appointments')
+      expect(categoryOptions[appointmentsIndex + 1]).toEqual({
+        text: 'Appointments with SPARKS activity',
+        value: 'appointments with sparks activity',
+        checked: false,
+      })
+    })
     it('should rename the appointments category to "All appointments" in the selected filter tag', () => {
       expect(flaggedRes.locals.filters.selectedFilterItems.category).toEqual([
         {

--- a/server/middleware/filterActivityLog.test.ts
+++ b/server/middleware/filterActivityLog.test.ts
@@ -15,6 +15,7 @@ interface Args {
   dateTo?: string
   compliance?: string | string[]
   category?: string | string[]
+  sparks?: string | string[]
   hideContact?: string | string[]
   clearFilterKey?: string
   clearFilterValue?: string
@@ -117,6 +118,7 @@ describe('/middleware/filterActivityLog()', () => {
         clearFilterValue: '',
         compliance: ['no outcome', 'complied', 'not complied'],
         category: categeoryList,
+        sparks: [],
         hideContact: ['hide NDelius system generated contacts'],
         dateFrom: '21/03/2025',
         dateTo: '22/03/2025',
@@ -170,6 +172,7 @@ describe('/middleware/filterActivityLog()', () => {
               href: `${url}?clearFilterKey=category&clearFilterValue=appointments`,
             },
           ],
+          sparks: [],
           hideContact: [
             {
               text: 'Hide NDelius system generated contacts',
@@ -183,6 +186,7 @@ describe('/middleware/filterActivityLog()', () => {
           value,
           checked: value === 'appointments',
         })),
+        sparksOptions: [],
         hideContactOptions: hideContactsFilterOptions.map(({ text, value }) => ({
           text,
           value,
@@ -192,6 +196,7 @@ describe('/middleware/filterActivityLog()', () => {
         keywords: req.query.keywords as string,
         compliance: [req.query.compliance] as string[],
         category: [req.query.category] as string[],
+        sparks: [],
         hideContact: [req.query.hideContact] as string[],
         dateFrom: req.query.dateFrom as string,
         dateTo: req.query.dateTo as string,
@@ -217,6 +222,7 @@ describe('/middleware/filterActivityLog()', () => {
       dateTo: '',
       compliance: 'complied',
       category: 'appointments',
+      sparks: 'appointments with sparks activity',
       hideContact: 'hide NDelius system generated contacts',
     })
     beforeEach(() => {
@@ -228,20 +234,32 @@ describe('/middleware/filterActivityLog()', () => {
       )
       expect(appointmentsOption.text).toEqual('All appointments')
     })
-    it('should add the SPARKS category directly after "All appointments" in the checkbox options', () => {
+    it('should not include the SPARKS category in the category checkbox options', () => {
       const { categoryOptions } = flaggedRes.locals.filters
-      const appointmentsIndex = categoryOptions.findIndex(option => option.value === 'appointments')
-      expect(categoryOptions[appointmentsIndex + 1]).toEqual({
-        text: 'Appointments with SPARKS activity',
-        value: 'appointments with sparks activity',
-        checked: false,
-      })
+      expect(categoryOptions.find(option => option.value === 'appointments with sparks activity')).toBeUndefined()
+    })
+    it('should expose the SPARKS filter in its own sparksOptions checkbox group', () => {
+      expect(flaggedRes.locals.filters.sparksOptions).toEqual([
+        {
+          text: 'Appointments with SPARKS activity',
+          value: 'appointments with sparks activity',
+          checked: true,
+        },
+      ])
     })
     it('should rename the appointments category to "All appointments" in the selected filter tag', () => {
       expect(flaggedRes.locals.filters.selectedFilterItems.category).toEqual([
         {
           text: 'All appointments',
           href: `/case/${crn}/activity-log?clearFilterKey=category&clearFilterValue=appointments`,
+        },
+      ])
+    })
+    it('should show the SPARKS filter as its own selected filter tag', () => {
+      expect(flaggedRes.locals.filters.selectedFilterItems.sparks).toEqual([
+        {
+          text: 'Appointments with SPARKS activity',
+          href: `/case/${crn}/activity-log?clearFilterKey=sparks&clearFilterValue=appointments%20with%20sparks%20activity`,
         },
       ])
     })
@@ -307,6 +325,7 @@ describe('/middleware/filterActivityLog()', () => {
               href: `${url}?clearFilterKey=category&clearFilterValue=${encodeURIComponent(item)}`,
             })),
           ],
+          sparks: [],
           hideContact: [
             ...(query.hideContact as string[]).map((item, i) => ({
               text: hideContactsFilterOptions[i].text,
@@ -322,11 +341,13 @@ describe('/middleware/filterActivityLog()', () => {
         },
         complianceOptions: filterOptions.map(({ text, value }) => ({ text, value, checked: true })),
         categoryOptions: categoryFilterOptions.map(({ text, value }) => ({ text, value, checked: true })),
+        sparksOptions: [],
         hideContactOptions: hideContactsFilterOptions.map(({ text, value }) => ({ text, value, checked: true })),
         baseUrl: `/case/${crn}/activity-log`,
         keywords: req.query.keywords as string,
         compliance: req.query.compliance as string[],
         category: req.query.category as string[],
+        sparks: [],
         hideContact: req.query.hideContact as string[],
         dateFrom: req.query.dateFrom as string,
         dateTo: req.query.dateTo as string,
@@ -396,6 +417,7 @@ describe('/middleware/filterActivityLog()', () => {
               href: `${url}?clearFilterKey=category&clearFilterValue=${encodeURIComponent(item)}`,
             })),
           ],
+          sparks: [],
           hideContact: [
             ...(query.hideContact as string[]).map((item, i) => ({
               text: hideContactsFilterOptions[i].text,
@@ -405,11 +427,13 @@ describe('/middleware/filterActivityLog()', () => {
         },
         complianceOptions: filterOptions.map(({ text, value }) => ({ text, value, checked: true })),
         categoryOptions: categoryFilterOptions.map(({ text, value }) => ({ text, value, checked: true })),
+        sparksOptions: [],
         hideContactOptions: hideContactsFilterOptions.map(({ text, value }) => ({ text, value, checked: true })),
         baseUrl: `/case/${crn}/activity-log`,
         keywords: req.query.keywords as string,
         compliance: req.query.compliance as string[],
         category: req.query.category as string[],
+        sparks: [],
         hideContact: req.query.hideContact as string[],
         dateFrom: '',
         dateTo: '',
@@ -451,6 +475,7 @@ describe('/middleware/filterActivityLog()', () => {
               href: `${url}?clearFilterKey=category&clearFilterValue=appointments`,
             },
           ],
+          sparks: [],
           hideContact: [
             {
               text: 'Hide NDelius system generated contacts',
@@ -476,6 +501,7 @@ describe('/middleware/filterActivityLog()', () => {
           value,
           checked: value === 'appointments',
         })),
+        sparksOptions: [],
         hideContactOptions: hideContactsFilterOptions.map(({ text, value }) => ({
           text,
           value,
@@ -485,6 +511,7 @@ describe('/middleware/filterActivityLog()', () => {
         keywords: 'testing',
         compliance: ['not complied'],
         category: ['appointments'],
+        sparks: [],
         hideContact: ['hide NDelius system generated contacts'],
         dateFrom: '20/03/2025',
         dateTo: '23/03/2025',

--- a/server/middleware/filterActivityLog.ts
+++ b/server/middleware/filterActivityLog.ts
@@ -69,6 +69,12 @@ export const filterActivityLog: Route<void> = (req, res, next): void => {
     }
   }
 
+  const categoryOptionsSource = res.locals.flags?.enableSparksFilter
+    ? categoryFilterOptions.map(option =>
+        option.value === 'appointments' ? { ...option, text: 'All appointments' } : option,
+      )
+    : categoryFilterOptions
+
   const baseUrl = `/case/${crn}/activity-log`
   const filters: ActivityLogFilters = {
     keywords,
@@ -112,7 +118,7 @@ export const filterActivityLog: Route<void> = (req, res, next): void => {
             })
           } else if (filterKey === 'category') {
             value.push({
-              text: categoryFilterOptions.find(option => option.value === text).text,
+              text: categoryOptionsSource.find(option => option.value === text).text,
               href: filterHref(filterKey, text),
             })
           } else if (filterKey === 'hideContact') {
@@ -141,7 +147,7 @@ export const filterActivityLog: Route<void> = (req, res, next): void => {
     checked: filters.compliance.includes(value),
   }))
 
-  const categoryOptions: Option[] = categoryFilterOptions.map(({ text, value }) => ({
+  const categoryOptions: Option[] = categoryOptionsSource.map(({ text, value }) => ({
     text,
     value,
     checked: filters.category.includes(value),

--- a/server/middleware/filterActivityLog.ts
+++ b/server/middleware/filterActivityLog.ts
@@ -20,7 +20,7 @@ export const filterActivityLog: Route<void> = (req, res, next): void => {
   const { clearFilterKey, clearFilterValue } = req.query
   const view = req?.query?.view ?? req?.body?.view
   const { crn } = req.params as Record<string, string>
-  const { keywords, dateFrom, dateTo, compliance, category, hideContact } = setSession()
+  const { keywords, dateFrom, dateTo, compliance, category, sparks, hideContact } = setSession()
   const errorMessages = req?.session?.errorMessages
 
   function setSession() {
@@ -30,10 +30,12 @@ export const filterActivityLog: Route<void> = (req, res, next): void => {
     if (req.body?.submit && !req?.query?.error) {
       const complianceFilters: Array<string> = req.body.compliance ? [req.body.compliance].flat() : []
       const categoryFilters: Array<string> = req.body.category ? [req.body.category].flat() : []
+      const sparksFilters: Array<string> = req.body.sparks ? [req.body.sparks].flat() : []
       const hideContactFilters: Array<string> = req.body.hideContact ? [req.body.hideContact].flat() : []
       req.session.activityLogFilters = req.body as ActivityLogFilters
       req.session.activityLogFilters.compliance = complianceFilters
       req.session.activityLogFilters.category = categoryFilters
+      req.session.activityLogFilters.sparks = sparksFilters
       req.session.activityLogFilters.hideContact = hideContactFilters
       req.session.activityLogFilters.crn = crn
     }
@@ -46,6 +48,7 @@ export const filterActivityLog: Route<void> = (req, res, next): void => {
       dateTo: req.session?.activityLogFilters?.dateTo ?? '',
       compliance: req.session?.activityLogFilters?.compliance ?? [],
       category: req.session?.activityLogFilters?.category ?? [],
+      sparks: req.session?.activityLogFilters?.sparks ?? [],
       hideContact: req.session?.activityLogFilters?.hideContact ?? [],
     }
   }
@@ -63,6 +66,10 @@ export const filterActivityLog: Route<void> = (req, res, next): void => {
       req.session.activityLogFilters.category = req.session.activityLogFilters.category.filter(
         (value: string) => value !== clearFilterValue,
       )
+    } else if (clearFilterKey === 'sparks') {
+      req.session.activityLogFilters.sparks = req.session.activityLogFilters.sparks.filter(
+        (value: string) => value !== clearFilterValue,
+      )
     } else if (clearFilterKey === 'hideContact') {
       req.session.activityLogFilters.hideContact = req.session.activityLogFilters.hideContact.filter(
         (value: string) => value !== clearFilterValue,
@@ -70,13 +77,13 @@ export const filterActivityLog: Route<void> = (req, res, next): void => {
     }
   }
 
-  const categoryOptionsSource = res.locals.flags?.enableSparksFilter
-    ? categoryFilterOptions.flatMap(option =>
-        option.value === 'appointments'
-          ? [{ ...option, text: 'All appointments' }, sparksCategoryFilterOption]
-          : [option],
+  const sparksEnabled = res.locals.flags?.enableSparksFilter === true
+  const categoryOptionsSource = sparksEnabled
+    ? categoryFilterOptions.map(option =>
+        option.value === 'appointments' ? { ...option, text: 'All appointments' } : option,
       )
     : categoryFilterOptions
+  const sparksOptionsSource = sparksEnabled ? [sparksCategoryFilterOption] : []
 
   const baseUrl = `/case/${crn}/activity-log`
   const filters: ActivityLogFilters = {
@@ -85,6 +92,7 @@ export const filterActivityLog: Route<void> = (req, res, next): void => {
     dateTo: dateTo && dateFrom && !errorMessages?.dateTo && clearFilterKey !== 'dateRange' ? dateTo : '',
     compliance,
     category,
+    sparks,
     hideContact,
   }
 
@@ -95,6 +103,11 @@ export const filterActivityLog: Route<void> = (req, res, next): void => {
         : `${baseUrl}?clearFilterKey=${key}&clearFilterValue=${encodeURIComponent(value)}`
     }
     if (key === 'category') {
+      return view
+        ? `${baseUrl}?clearFilterKey=${key}&clearFilterValue=${encodeURIComponent(value)}&view=${view}`
+        : `${baseUrl}?clearFilterKey=${key}&clearFilterValue=${encodeURIComponent(value)}`
+    }
+    if (key === 'sparks') {
       return view
         ? `${baseUrl}?clearFilterKey=${key}&clearFilterValue=${encodeURIComponent(value)}&view=${view}`
         : `${baseUrl}?clearFilterKey=${key}&clearFilterValue=${encodeURIComponent(value)}`
@@ -124,6 +137,14 @@ export const filterActivityLog: Route<void> = (req, res, next): void => {
             if (categoryOption) {
               value.push({
                 text: categoryOption.text,
+                href: filterHref(filterKey, text),
+              })
+            }
+          } else if (filterKey === 'sparks') {
+            const sparksOption = sparksOptionsSource.find(option => option.value === text)
+            if (sparksOption) {
+              value.push({
+                text: sparksOption.text,
                 href: filterHref(filterKey, text),
               })
             }
@@ -159,6 +180,12 @@ export const filterActivityLog: Route<void> = (req, res, next): void => {
     checked: filters.category.includes(value),
   }))
 
+  const sparksOptions: Option[] = sparksOptionsSource.map(({ text, value }) => ({
+    text,
+    value,
+    checked: filters.sparks.includes(value),
+  }))
+
   const hideContactOptions: Option[] = hideContactsFilterOptions.map(({ text, value }) => ({
     text,
     value,
@@ -172,11 +199,13 @@ export const filterActivityLog: Route<void> = (req, res, next): void => {
     selectedFilterItems,
     complianceOptions,
     categoryOptions,
+    sparksOptions,
     hideContactOptions,
     baseUrl,
     keywords: filters.keywords,
     compliance: filters.compliance,
     category: filters.category,
+    sparks: filters.sparks,
     dateFrom: filters.dateFrom,
     dateTo: filters.dateTo,
     hideContact: filters.hideContact,

--- a/server/middleware/filterActivityLog.ts
+++ b/server/middleware/filterActivityLog.ts
@@ -96,28 +96,12 @@ export const filterActivityLog: Route<void> = (req, res, next): void => {
     hideContact,
   }
 
+  const keysWithClearValue = ['compliance', 'category', 'sparks', 'hideContact']
   const filterHref = (key: string, value: string): string => {
-    if (key === 'compliance') {
-      return view
-        ? `${baseUrl}?clearFilterKey=${key}&clearFilterValue=${encodeURIComponent(value)}&view=${view}`
-        : `${baseUrl}?clearFilterKey=${key}&clearFilterValue=${encodeURIComponent(value)}`
-    }
-    if (key === 'category') {
-      return view
-        ? `${baseUrl}?clearFilterKey=${key}&clearFilterValue=${encodeURIComponent(value)}&view=${view}`
-        : `${baseUrl}?clearFilterKey=${key}&clearFilterValue=${encodeURIComponent(value)}`
-    }
-    if (key === 'sparks') {
-      return view
-        ? `${baseUrl}?clearFilterKey=${key}&clearFilterValue=${encodeURIComponent(value)}&view=${view}`
-        : `${baseUrl}?clearFilterKey=${key}&clearFilterValue=${encodeURIComponent(value)}`
-    }
-    if (key === 'hideContact') {
-      return view
-        ? `${baseUrl}?clearFilterKey=${key}&clearFilterValue=${encodeURIComponent(value)}&view=${view}`
-        : `${baseUrl}?clearFilterKey=${key}&clearFilterValue=${encodeURIComponent(value)}`
-    }
-    return view ? `${baseUrl}?clearFilterKey=${key}&view=${view}` : `${baseUrl}?clearFilterKey=${key}`
+    const base = keysWithClearValue.includes(key)
+      ? `${baseUrl}?clearFilterKey=${key}&clearFilterValue=${encodeURIComponent(value)}`
+      : `${baseUrl}?clearFilterKey=${key}`
+    return view ? `${base}&view=${view}` : base
   }
 
   const selectedFilterItems: Record<string, SelectedFilterItem[]> = Object.entries(filters)

--- a/server/middleware/filterActivityLog.ts
+++ b/server/middleware/filterActivityLog.ts
@@ -5,6 +5,7 @@ import { Route } from '../@types'
 
 import {
   categoryFilterOptions,
+  sparksCategoryFilterOption,
   filterOptions as complianceFilterOptions,
   hideContactsFilterOptions,
 } from '../properties'
@@ -70,8 +71,10 @@ export const filterActivityLog: Route<void> = (req, res, next): void => {
   }
 
   const categoryOptionsSource = res.locals.flags?.enableSparksFilter
-    ? categoryFilterOptions.map(option =>
-        option.value === 'appointments' ? { ...option, text: 'All appointments' } : option,
+    ? categoryFilterOptions.flatMap(option =>
+        option.value === 'appointments'
+          ? [{ ...option, text: 'All appointments' }, sparksCategoryFilterOption]
+          : [option],
       )
     : categoryFilterOptions
 

--- a/server/middleware/filterActivityLog.ts
+++ b/server/middleware/filterActivityLog.ts
@@ -120,10 +120,13 @@ export const filterActivityLog: Route<void> = (req, res, next): void => {
               href: filterHref(filterKey, text),
             })
           } else if (filterKey === 'category') {
-            value.push({
-              text: categoryOptionsSource.find(option => option.value === text).text,
-              href: filterHref(filterKey, text),
-            })
+            const categoryOption = categoryOptionsSource.find(option => option.value === text)
+            if (categoryOption) {
+              value.push({
+                text: categoryOption.text,
+                href: filterHref(filterKey, text),
+              })
+            }
           } else if (filterKey === 'hideContact') {
             value.push({
               text: hideContactsFilterOptions.find(option => option.value === text).text,

--- a/server/middleware/getPersonActivity.test.ts
+++ b/server/middleware/getPersonActivity.test.ts
@@ -251,4 +251,35 @@ describe('/middleware/getPersonActivity', () => {
     )
     res.locals.flags = {}
   })
+
+  it('should not apply the SPARKS filter when enableSparksFilter is disabled, even if the session holds a SPARKS value', async () => {
+    req.params = { crn }
+    req.query = { page: '0' }
+    res.locals.flags = {}
+    res.locals.filters = {
+      ...filterVals,
+      compliance: ['complied'],
+      category: [],
+      sparks: ['appointments with sparks activity'],
+      complianceOptions: [],
+      categoryOptions: [],
+      sparksOptions: [],
+      hideContactOptions: [],
+      selectedFilterItems: {},
+      baseUrl: '',
+      query: { ...filterVals },
+      maxDate: '21/1/2025',
+      crn,
+    }
+
+    const hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
+
+    await getPersonActivity(req, res, hmppsAuthClient)
+    expect(masSpy).toHaveBeenCalledWith(
+      crn,
+      expect.objectContaining({ filters: ['complied'], typeCodes: [] }),
+      '0',
+      String(ACTIVITY_LOG_PAGE_SIZE),
+    )
+  })
 })

--- a/server/middleware/getPersonActivity.test.ts
+++ b/server/middleware/getPersonActivity.test.ts
@@ -7,7 +7,7 @@ import TierApiClient from '../data/tierApiClient'
 import { toIsoDateFromPicker } from '../utils'
 import { ActivityLogRequestBody } from '../models/ActivityLog'
 import { Document } from '../data/model/personalDetails'
-import { APPOINTMENTS_CODES, ACTIVITY_LOG_PAGE_SIZE } from '../properties'
+import { APPOINTMENTS_CODES, SPARKS_CODES, ACTIVITY_LOG_PAGE_SIZE } from '../properties'
 
 jest.mock('../data/masApiClient')
 jest.mock('../data/hmppsAuthClient')
@@ -185,5 +185,34 @@ describe('/middleware/getPersonActivity', () => {
     expect(tierSpy).toHaveBeenCalledWith(crn)
     expect(personActivity).toEqual(mockPersonActivityResponse)
     expect(tierCalculation).toEqual(mockTierCalculationResponse)
+  })
+
+  it('should map the SPARKS category to its type codes when enableSparksFilter is enabled', async () => {
+    req.params = { crn }
+    req.query = { page: '0' }
+    res.locals.flags = { enableSparksFilter: true }
+    res.locals.filters = {
+      ...filterVals,
+      category: ['appointments with sparks activity'],
+      complianceOptions: [],
+      categoryOptions: [],
+      hideContactOptions: [],
+      selectedFilterItems: {},
+      baseUrl: '',
+      query: { ...filterVals },
+      maxDate: '21/1/2025',
+      crn,
+    }
+
+    const hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
+
+    await getPersonActivity(req, res, hmppsAuthClient)
+    expect(masSpy).toHaveBeenCalledWith(
+      crn,
+      expect.objectContaining({ typeCodes: SPARKS_CODES }),
+      '0',
+      String(ACTIVITY_LOG_PAGE_SIZE),
+    )
+    res.locals.flags = {}
   })
 })

--- a/server/middleware/getPersonActivity.test.ts
+++ b/server/middleware/getPersonActivity.test.ts
@@ -7,7 +7,7 @@ import TierApiClient from '../data/tierApiClient'
 import { toIsoDateFromPicker } from '../utils'
 import { ActivityLogRequestBody } from '../models/ActivityLog'
 import { Document } from '../data/model/personalDetails'
-import { APPOINTMENTS_CODES, SPARKS_CODES, ACTIVITY_LOG_PAGE_SIZE } from '../properties'
+import { APPOINTMENTS_CODES, SPARKS_FILTER_VALUE, ACTIVITY_LOG_PAGE_SIZE } from '../properties'
 
 jest.mock('../data/masApiClient')
 jest.mock('../data/hmppsAuthClient')
@@ -153,6 +153,7 @@ describe('/middleware/getPersonActivity', () => {
       ...filterVals,
       complianceOptions: [],
       categoryOptions: [],
+      sparksOptions: [],
       hideContactOptions: [],
       selectedFilterItems: {},
       baseUrl: '',
@@ -187,15 +188,18 @@ describe('/middleware/getPersonActivity', () => {
     expect(tierCalculation).toEqual(mockTierCalculationResponse)
   })
 
-  it('should map the SPARKS category to its type codes when enableSparksFilter is enabled', async () => {
+  it('should map the SPARKS filter to the request body filters (not typeCodes) when enableSparksFilter is enabled', async () => {
     req.params = { crn }
     req.query = { page: '0' }
     res.locals.flags = { enableSparksFilter: true }
     res.locals.filters = {
       ...filterVals,
-      category: ['appointments with sparks activity'],
+      compliance: [],
+      category: [],
+      sparks: ['appointments with sparks activity'],
       complianceOptions: [],
       categoryOptions: [],
+      sparksOptions: [],
       hideContactOptions: [],
       selectedFilterItems: {},
       baseUrl: '',
@@ -209,7 +213,39 @@ describe('/middleware/getPersonActivity', () => {
     await getPersonActivity(req, res, hmppsAuthClient)
     expect(masSpy).toHaveBeenCalledWith(
       crn,
-      expect.objectContaining({ typeCodes: SPARKS_CODES }),
+      expect.objectContaining({ filters: [SPARKS_FILTER_VALUE], typeCodes: [] }),
+      '0',
+      String(ACTIVITY_LOG_PAGE_SIZE),
+    )
+    res.locals.flags = {}
+  })
+
+  it('should keep category filters in typeCodes while routing SPARKS to filters', async () => {
+    req.params = { crn }
+    req.query = { page: '0' }
+    res.locals.flags = { enableSparksFilter: true }
+    res.locals.filters = {
+      ...filterVals,
+      compliance: ['complied'],
+      category: ['appointments'],
+      sparks: ['appointments with sparks activity'],
+      complianceOptions: [],
+      categoryOptions: [],
+      sparksOptions: [],
+      hideContactOptions: [],
+      selectedFilterItems: {},
+      baseUrl: '',
+      query: { ...filterVals },
+      maxDate: '21/1/2025',
+      crn,
+    }
+
+    const hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
+
+    await getPersonActivity(req, res, hmppsAuthClient)
+    expect(masSpy).toHaveBeenCalledWith(
+      crn,
+      expect.objectContaining({ filters: ['complied', SPARKS_FILTER_VALUE], typeCodes: APPOINTMENTS_CODES }),
       '0',
       String(ACTIVITY_LOG_PAGE_SIZE),
     )

--- a/server/middleware/getPersonActivity.ts
+++ b/server/middleware/getPersonActivity.ts
@@ -6,7 +6,7 @@ import TierApiClient, { TierCalculation } from '../data/tierApiClient'
 import { toIsoDateFromPicker, toCamelCase } from '../utils'
 import { AppResponse } from '../models/Locals'
 import { ActivityLogRequestBody, SelectedFilterItem } from '../models/ActivityLog'
-import { categoryFilterOptions, ACTIVITY_LOG_PAGE_SIZE } from '../properties'
+import { categoryFilterOptions, sparksCategoryFilterOption, ACTIVITY_LOG_PAGE_SIZE } from '../properties'
 
 export const getPersonActivity = async (
   req: Request,
@@ -22,10 +22,14 @@ export const getPersonActivity = async (
   const masClient = new MasApiClient(token)
   const tierClient = new TierApiClient(token)
 
+  const categoryOptions = res.locals.flags?.enableSparksFilter
+    ? [...categoryFilterOptions, sparksCategoryFilterOption]
+    : categoryFilterOptions
+
   const combinedCategoryCodes: string[] = []
   if (Array.isArray(category)) {
     for (const val of category) {
-      combinedCategoryCodes.push(...(categoryFilterOptions.find(option => option.value === val)?.codes || []))
+      combinedCategoryCodes.push(...(categoryOptions.find(option => option.value === val)?.codes || []))
     }
   }
 

--- a/server/middleware/getPersonActivity.ts
+++ b/server/middleware/getPersonActivity.ts
@@ -15,22 +15,23 @@ export const getPersonActivity = async (
 ): Promise<[TierCalculation, PersonActivity]> => {
   const { filters } = res.locals
   const { params, query } = req
-  const { keywords, dateFrom, dateTo, compliance, category, hideContact } = filters
+  const { keywords, dateFrom, dateTo, compliance, category, sparks, hideContact } = filters
   const { crn } = params as Record<string, string>
   const { page = '0' } = query
   const token = await hmppsAuthClient.getSystemClientToken(res.locals.user.username)
   const masClient = new MasApiClient(token)
   const tierClient = new TierApiClient(token)
 
-  const categoryOptions = res.locals.flags?.enableSparksFilter
-    ? [...categoryFilterOptions, sparksCategoryFilterOption]
-    : categoryFilterOptions
-
   const combinedCategoryCodes: string[] = []
   if (Array.isArray(category)) {
     for (const val of category) {
-      combinedCategoryCodes.push(...(categoryOptions.find(option => option.value === val)?.codes || []))
+      combinedCategoryCodes.push(...(categoryFilterOptions.find(option => option.value === val)?.codes || []))
     }
+  }
+
+  const sparksFilters: string[] = []
+  if (Array.isArray(sparks) && sparks.includes(sparksCategoryFilterOption.value)) {
+    sparksFilters.push(...sparksCategoryFilterOption.codes)
   }
 
   const formatCompliance = (): Array<string> => {
@@ -49,7 +50,7 @@ export const getPersonActivity = async (
     keywords,
     dateFrom: dateFrom ? toIsoDateFromPicker(dateFrom) : '',
     dateTo: dateTo ? toIsoDateFromPicker(dateTo) : '',
-    filters: formatCompliance(),
+    filters: [...formatCompliance(), ...sparksFilters],
     includeSystemGenerated: hideContact?.length === 0,
     typeCodes: combinedCategoryCodes,
   }

--- a/server/middleware/getPersonActivity.ts
+++ b/server/middleware/getPersonActivity.ts
@@ -30,7 +30,11 @@ export const getPersonActivity = async (
   }
 
   const sparksFilters: string[] = []
-  if (Array.isArray(sparks) && sparks.includes(sparksCategoryFilterOption.value)) {
+  if (
+    res.locals.flags?.enableSparksFilter &&
+    Array.isArray(sparks) &&
+    sparks.includes(sparksCategoryFilterOption.value)
+  ) {
     sparksFilters.push(...sparksCategoryFilterOption.codes)
   }
 

--- a/server/models/ActivityLog.ts
+++ b/server/models/ActivityLog.ts
@@ -6,6 +6,7 @@ export interface ActivityLogFilters {
   dateTo: string
   compliance: Array<string> | string
   category: string[]
+  sparks?: string[]
   clearFilterKey?: string
   clearFilterValue?: string
   hideContact?: Array<string>
@@ -29,6 +30,7 @@ export interface ActivityLogFiltersResponse extends ActivityLogFilters {
   selectedFilterItems: Record<string, SelectedFilterItem[]>
   complianceOptions: Option[]
   categoryOptions: Option[]
+  sparksOptions: Option[]
   hideContactOptions: Option[]
   baseUrl: string
   maxDate: string

--- a/server/properties/filterOptions.ts
+++ b/server/properties/filterOptions.ts
@@ -558,6 +558,33 @@ export const ENFORCEMENT_CODES: string[] = [
   'C145',
 ]
 
+export const SPARKS_CODES: string[] = [
+  'SPK001',
+  'SPK002',
+  'SPK003',
+  'SPK004',
+  'SPK005',
+  'SPK006',
+  'SPK007',
+  'SPK008',
+  'SPK009',
+  'SPK010',
+  'SPK011',
+  'SPK012',
+  'SPK013',
+  'SPK014',
+  'SPK015',
+  'SPK016',
+  'SPK017',
+  'SPK018',
+]
+
+export const sparksCategoryFilterOption = {
+  text: 'Appointments with SPARKS activity',
+  value: 'appointments with sparks activity',
+  codes: SPARKS_CODES,
+}
+
 export const categoryFilterOptions = [
   { text: 'Appointments', value: 'appointments', codes: APPOINTMENTS_CODES },
   { text: 'Approved Premises', value: 'Approved Premises', codes: APPROVED_PREMISES_CODES },

--- a/server/properties/filterOptions.ts
+++ b/server/properties/filterOptions.ts
@@ -558,31 +558,12 @@ export const ENFORCEMENT_CODES: string[] = [
   'C145',
 ]
 
-export const SPARKS_CODES: string[] = [
-  'SPK001',
-  'SPK002',
-  'SPK003',
-  'SPK004',
-  'SPK005',
-  'SPK006',
-  'SPK007',
-  'SPK008',
-  'SPK009',
-  'SPK010',
-  'SPK011',
-  'SPK012',
-  'SPK013',
-  'SPK014',
-  'SPK015',
-  'SPK016',
-  'SPK017',
-  'SPK018',
-]
+export const SPARKS_FILTER_VALUE = 'sparks'
 
 export const sparksCategoryFilterOption = {
   text: 'Appointments with SPARKS activity',
   value: 'appointments with sparks activity',
-  codes: SPARKS_CODES,
+  codes: [SPARKS_FILTER_VALUE],
 }
 
 export const categoryFilterOptions = [

--- a/server/views/pages/contact-log/_filters.njk
+++ b/server/views/pages/contact-log/_filters.njk
@@ -88,6 +88,26 @@
     items: filters.complianceOptions
   }) }}
 
+  {% if filters.sparksOptions.length %}
+  {{ govukCheckboxes({
+    idPrefix: 'sparks',
+    name: 'sparks',
+    classes: "govuk-checkboxes--small",
+    fieldset: {
+      legend: {
+        text: 'SPARKS filters',
+        classes: 'govuk-fieldset__legend--s'
+      }
+    },
+    formGroup: {
+      attributes: {
+        'data-qa': 'sparks'
+      }
+    },
+    items: filters.sparksOptions
+  }) }}
+  {% endif %}
+
   {{ govukCheckboxes({
     idPrefix: 'category',
     name: 'category',
@@ -140,6 +160,15 @@
             text: 'Category filters'
         },
         items: filters.selectedFilterItems.category
+    }), filterCategories) %}
+{% endif %}
+
+{% if filters.selectedFilterItems.sparks.length %}
+    {% set filterCategories = (filterCategories.push({
+        heading: {
+            text: 'SPARKS filters'
+        },
+        items: filters.selectedFilterItems.sparks
     }), filterCategories) %}
 {% endif %}
 
@@ -196,7 +225,7 @@
       href: '/case/' + crn + '/activity-log' + clearLink
     },
     categories: filterCategories
-  } if filters.selectedFilterItems.keywords.length or filters.selectedFilterItems.dateRange.length or filters.selectedFilterItems.compliance.length or filters.selectedFilterItems.category.length,
+  } if filters.selectedFilterItems.keywords.length or filters.selectedFilterItems.dateRange.length or filters.selectedFilterItems.compliance.length or filters.selectedFilterItems.category.length or filters.selectedFilterItems.sparks.length,
   optionsHtml: filterOptionsHtml
 }) }}
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">


### PR DESCRIPTION
MAN-2955

## Summary
- Adds a new **SPARKS filter to the Activity Log (contact log) page
- Renames the existing **Appointments** category to **All appointments**
  to distinguish it from the new SPARKS-specific filter.
- Feature flag changes - `enableSparksFilter`

<img width="505" height="719" alt="image" src="https://github.com/user-attachments/assets/b79498df-bc0b-4cf6-910b-e3ea7264295c" />
