### PR TITLE
[ESUP-1939] Implement feature flag and routing (for ESUP question flow de-integration)

### DIFF
--- a/server/data/model/featureFlags.ts
+++ b/server/data/model/featureFlags.ts
@@ -21,4 +21,5 @@ export class FeatureFlags {
   enableBreachOrRecallAndSendLetterAction?: boolean = undefined
   enableSessionCacheLogging?: boolean = undefined
   enableESUPCheckinNewStop?: boolean = undefined
+  enableESUPCheckinNewQuestions?: boolean = undefined
 }

--- a/server/middleware/redirectToManageCheckInService.test.ts
+++ b/server/middleware/redirectToManageCheckInService.test.ts
@@ -97,4 +97,13 @@ describe('redirectToManageCheckInService', () => {
 
     expect(redirectSpy).toHaveBeenCalledWith(`${link}${path}`)
   })
+
+  it('redirects when enableESUPCheckinNewQuestions is enabled', () => {
+    const res = mockAppResponse({ flags: { enableESUPCheckinNewQuestions: true } })
+    const redirectSpy = jest.spyOn(res, 'redirect')
+
+    redirectToManageCheckInService('enableESUPCheckinNewQuestions')(createReq(), res, jest.fn())
+
+    expect(redirectSpy).toHaveBeenCalledWith(`${link}${path}`)
+  })
 })

--- a/server/middleware/redirectToManageCheckInService.test.ts
+++ b/server/middleware/redirectToManageCheckInService.test.ts
@@ -1,0 +1,100 @@
+import httpMocks from 'node-mocks-http'
+import { mockAppResponse } from '../controllers/mocks'
+import config from '../config'
+import { redirectToManageCheckInService } from './redirectToManageCheckInService'
+
+const crn = 'X000001'
+const id = 'f1654ea3-0abb-46eb-860b-654a96edbe20'
+const { link } = config.eSupervisionManageCheckins
+const path = `/case/${crn}/appointments/${id}/check-in/update`
+
+const createReq = (query: Record<string, string> = {}, url = path) =>
+  httpMocks.createRequest({ params: { crn, id }, query, originalUrl: url })
+
+const redirect = () => redirectToManageCheckInService('enableESUPCheckinNewReview')
+
+describe('redirectToManageCheckInService', () => {
+  it('calls next when the flag is not enabled', () => {
+    const res = mockAppResponse({ flags: { enableESUPCheckinNewReview: false } })
+    const redirectSpy = jest.spyOn(res, 'redirect')
+    const nextSpy = jest.fn()
+
+    redirect()(createReq(), res, nextSpy)
+
+    expect(redirectSpy).not.toHaveBeenCalled()
+    expect(nextSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls next when there are no flags', () => {
+    const res = mockAppResponse({})
+    const redirectSpy = jest.spyOn(res, 'redirect')
+    const nextSpy = jest.fn()
+
+    redirect()(createReq(), res, nextSpy)
+
+    expect(redirectSpy).not.toHaveBeenCalled()
+    expect(nextSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('only reacts to the flag it was given', () => {
+    const res = mockAppResponse({ flags: { enableESUPCheckinNewStop: true } })
+    const redirectSpy = jest.spyOn(res, 'redirect')
+    const nextSpy = jest.fn()
+
+    redirect()(createReq(), res, nextSpy)
+
+    expect(redirectSpy).not.toHaveBeenCalled()
+    expect(nextSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('redirects to the manage check-ins service when the flag is enabled', () => {
+    const res = mockAppResponse({ flags: { enableESUPCheckinNewReview: true } })
+    const redirectSpy = jest.spyOn(res, 'redirect')
+    const nextSpy = jest.fn()
+
+    redirect()(createReq(), res, nextSpy)
+
+    expect(redirectSpy).toHaveBeenCalledWith(`${link}${path}`)
+    expect(nextSpy).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['update', `/case/${crn}/appointments/${id}/check-in/update`],
+    ['view', `/case/${crn}/appointments/${id}/check-in/view`],
+    ['view-expired', `/case/${crn}/appointments/${id}/check-in/view-expired`],
+    ['review/identity', `/case/${crn}/appointments/${id}/check-in/review/identity`],
+    ['review/notes', `/case/${crn}/appointments/${id}/check-in/review/notes`],
+    ['review/expired', `/case/${crn}/appointments/${id}/check-in/review/expired`],
+  ])('passes the %s path through unchanged', (_: string, url: string) => {
+    const res = mockAppResponse({ flags: { enableESUPCheckinNewReview: true } })
+    const redirectSpy = jest.spyOn(res, 'redirect')
+
+    redirect()(createReq({}, url), res, jest.fn())
+
+    expect(redirectSpy).toHaveBeenCalledWith(`${link}${url}`)
+  })
+
+  it('makes the back url absolute so it returns to this service', () => {
+    const res = mockAppResponse({ flags: { enableESUPCheckinNewReview: true } })
+    const redirectSpy = jest.spyOn(res, 'redirect')
+    const backPath = `/case/${crn}/activity-log?page=1`
+
+    redirect()(createReq({ back: backPath }, `${path}?back=${encodeURIComponent(backPath)}`), res, jest.fn())
+
+    const back = encodeURIComponent(`${config.domain}${backPath}`)
+    expect(redirectSpy).toHaveBeenCalledWith(`${link}${path}?back=${back}`)
+  })
+
+  it.each([
+    ['a protocol relative url', '//evil.example.com/phish'],
+    ['an absolute url', 'https://evil.example.com/phish'],
+    ['a value that is not a path', 'evil'],
+  ])('drops the back param when it is %s', (_: string, back: string) => {
+    const res = mockAppResponse({ flags: { enableESUPCheckinNewReview: true } })
+    const redirectSpy = jest.spyOn(res, 'redirect')
+
+    redirect()(createReq({ back }, `${path}?back=${encodeURIComponent(back)}`), res, jest.fn())
+
+    expect(redirectSpy).toHaveBeenCalledWith(`${link}${path}`)
+  })
+})

--- a/server/middleware/redirectToManageCheckInService.ts
+++ b/server/middleware/redirectToManageCheckInService.ts
@@ -1,0 +1,31 @@
+import { NextFunction, Request } from 'express'
+import { AppResponse } from '../models/Locals'
+import { Route } from '../@types'
+import config from '../config'
+
+export type NewCheckInServiceFlag = 'enableESUPCheckinNewReview' | 'enableESUPCheckinNewQuestions'
+
+const stripTrailingSlash = (url: string): string => url.replace(/\/$/, '')
+
+// `back` param is a relative url, so it has to be made absolute before it is
+// redirecting to the manage online check-ins service
+const absoluteBackUrl = (back: unknown): string | null => {
+  if (typeof back !== 'string' || !back.startsWith('/') || back.startsWith('//')) {
+    return null
+  }
+  return `${stripTrailingSlash(config.domain)}${back}`
+}
+
+// The manage online check-ins service mirrors this service's check-in URLs, so the
+// requested path is passed through as-is rather than rebuilt per journey.
+export const redirectToManageCheckInService = (flag: NewCheckInServiceFlag): Route<void> => {
+  return (req: Request, res: AppResponse, next: NextFunction): void => {
+    if (res.locals.flags?.[flag] !== true) {
+      return next()
+    }
+    const [path] = req.originalUrl.split('?')
+    const link = `${stripTrailingSlash(config.eSupervisionManageCheckins.link)}${path}`
+    const back = absoluteBackUrl(req.query.back)
+    return res.redirect(back ? `${link}?back=${encodeURIComponent(back)}` : link)
+  }
+}

--- a/server/routes/eSupervisionCheckins.ts
+++ b/server/routes/eSupervisionCheckins.ts
@@ -7,6 +7,7 @@ import { getCheckIn } from '../middleware/getCheckIn'
 import { postRedirectWizard } from '../middleware/checkinCyaRedirect'
 import { AppResponse } from '../models/Locals'
 import { getCheckInQuestionsRedirect } from '../middleware/getCheckInQuestionsRedirect'
+import { redirectToManageCheckInService } from '../middleware/redirectToManageCheckInService'
 
 export default function eSuperVisionCheckInsRoutes(router: Router, { hmppsAuthClient }: Services) {
   router.use(
@@ -325,6 +326,22 @@ export default function eSuperVisionCheckInsRoutes(router: Router, { hmppsAuthCl
     autoStoreSessionData(hmppsAuthClient),
     controllers.checkIns.postReviewCheckIn(hmppsAuthClient),
   ])
+
+  // Check these routes against the enableESUPCheckinNewQuestions flag
+  // and redirect to the manage online check-ins service if set
+  router.use(
+    [
+      '/case/:crn/appointments/check-in/manage/:id/questions/start',
+      '/case/:crn/appointments/check-in/manage/:id/questions/add',
+      '/case/:crn/appointments/check-in/manage/:id/questions/list',
+      '/case/:crn/appointments/check-in/manage/:id/questions/:questionId/edit',
+      '/case/:crn/appointments/check-in/manage/:id/questions/:templateId/select',
+      '/case/:crn/appointments/check-in/manage/:id/questions/:questionId/delete',
+      '/case/:crn/appointments/check-in/manage/:id/questions/preview/feeling',
+      '/case/:crn/appointments/check-in/manage/:id/questions/preview/support',
+    ],
+    redirectToManageCheckInService('enableESUPCheckinNewQuestions'),
+  )
 
   router.get('/case/:crn/appointments/check-in/manage/:id/questions/start', [
     getCheckInQuestionsRedirect(hmppsAuthClient),

--- a/wiremock/mappings/flipt.json
+++ b/wiremock/mappings/flipt.json
@@ -198,6 +198,17 @@
               "updatedAt": "2026-07-08T12:00:00.000000Z",
               "rules": [],
               "rollouts": []
+            },
+            {
+              "key": "enableESUPCheckinNewQuestions",
+              "name": "enableESUPCheckinNewQuestions",
+              "description": "",
+              "enabled": false,
+              "type": "BOOLEAN_FLAG_TYPE",
+              "createdAt": "2026-07-08T12:00:00.000000Z",
+              "updatedAt": "2026-07-08T12:00:00.000000Z",
+              "rules": [],
+              "rollouts": []
             }
           ]
         }

--- a/wiremock/stubs/flags.ts
+++ b/wiremock/stubs/flags.ts
@@ -415,6 +415,37 @@ const stubEnableESUPCheckinNewStop = (): SuperAgentRequest =>
       },
     },
   })
+const stubEnableESUPCheckinNewQuestions = (): SuperAgentRequest =>
+  superagent.post('http://localhost:9091/__admin/mappings').send({
+    request: {
+      urlPathPattern: '/flipt/internal/v1/evaluation/snapshot/namespace/manage-people-on-probation-ui',
+      method: 'GET',
+    },
+    response: {
+      status: 200,
+      jsonBody: {
+        namespace: {
+          key: 'manage-people-on-probation-ui',
+        },
+        flags: [
+          {
+            key: 'enableESUPCheckinNewQuestions',
+            name: 'enableESUPCheckinNewQuestions',
+            description: '',
+            enabled: true,
+            type: 'BOOLEAN_FLAG_TYPE',
+            createdAt: '2026-07-08T12:00:00.000000Z',
+            updatedAt: '2026-07-08T12:00:00.000000Z',
+            rules: [],
+            rollouts: [],
+          },
+        ],
+      },
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    },
+  })
 
 export default {
   stubEnableESuperVision,
@@ -428,4 +459,5 @@ export default {
   stubDisableEnforcementContacts,
   stubFeatureFlag,
   stubEnableESUPCheckinNewStop,
+  stubEnableESUPCheckinNewQuestions,
 }

--- a/wiremock/stubs/flags.ts
+++ b/wiremock/stubs/flags.ts
@@ -415,37 +415,6 @@ const stubEnableESUPCheckinNewStop = (): SuperAgentRequest =>
       },
     },
   })
-const stubEnableESUPCheckinNewQuestions = (): SuperAgentRequest =>
-  superagent.post('http://localhost:9091/__admin/mappings').send({
-    request: {
-      urlPathPattern: '/flipt/internal/v1/evaluation/snapshot/namespace/manage-people-on-probation-ui',
-      method: 'GET',
-    },
-    response: {
-      status: 200,
-      jsonBody: {
-        namespace: {
-          key: 'manage-people-on-probation-ui',
-        },
-        flags: [
-          {
-            key: 'enableESUPCheckinNewQuestions',
-            name: 'enableESUPCheckinNewQuestions',
-            description: '',
-            enabled: true,
-            type: 'BOOLEAN_FLAG_TYPE',
-            createdAt: '2026-07-08T12:00:00.000000Z',
-            updatedAt: '2026-07-08T12:00:00.000000Z',
-            rules: [],
-            rollouts: [],
-          },
-        ],
-      },
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    },
-  })
 
 export default {
   stubEnableESuperVision,
@@ -459,5 +428,4 @@ export default {
   stubDisableEnforcementContacts,
   stubFeatureFlag,
   stubEnableESUPCheckinNewStop,
-  stubEnableESUPCheckinNewQuestions,
 }


### PR DESCRIPTION
[ESUP-1939](https://dsdmoj.atlassian.net/browse/ESUP-1939)

This PR adds a new feature flag enableESUPCheckinNewQuestions. When enabled, it will redirect users away from MPOP's own question check in pages, and will navigate to the new manage online check ins build.

This is part of the ESUP de-integration to move the online check in journeys to a new repo.

Currently set to true in Flipt DEV to enable testing. Set to false in Flipt PREPROD and PROD.

Our new repo still needs a few more changes until we're ready for prod deployment so this won't be enabled in prod until that is done.

[ESUP-1939]: https://dsdmoj.atlassian.net/browse/ESUP-1939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ