### PR TITLE
MAN-3006 fix repost of action when adding notes

### DIFF
--- a/server/middleware/appointment-outcomes/handlePutOutcome.test.ts
+++ b/server/middleware/appointment-outcomes/handlePutOutcome.test.ts
@@ -366,4 +366,29 @@ describe('middleware/appointment-outcomes/handlePutOutcome', () => {
     expect(postEnforcementActionsSpy).toHaveBeenCalledWith(contactId, expectedEnforcementActionRequest)
     expect(nextSpy).toHaveBeenCalledTimes(1)
   })
+
+  it('should not post the enforcement actions if adding appointment notes', async () => {
+    const appointment: Partial<AppointmentSession> = { notes }
+    const outcome: Partial<AppointmentSessionOutcome> = {
+      outcomeType: 'ATTENDED_FAILED_TO_COMPLY',
+      outcomeCode: 'AFTC',
+      attendedFailedToComply: 'BREACH_RECALL_INITIATED',
+      enforcementActionCode: ['IBR'],
+    }
+    const req = buildRequest({ put: 'true' })
+    const res = buildResponse({ appointment, outcome })
+    await handlePutOutcome(hmppsAuthClient)(req, res, nextSpy)
+    const { date, start } = mockAppointment()
+    const expectedRequest: PutContactRequest = {
+      date,
+      time: start,
+      outcomeCode: outcome.outcomeCode,
+      notes: `${notePrepend}\n${notes}`,
+      sensitive: true,
+      alert: false,
+    }
+    expect(putContactSpy).toHaveBeenCalledWith(contactId, expectedRequest)
+    expect(postEnforcementActionsSpy).not.toHaveBeenCalled()
+    expect(nextSpy).toHaveBeenCalledTimes(1)
+  })
 })

--- a/server/middleware/appointment-outcomes/handlePutOutcome.ts
+++ b/server/middleware/appointment-outcomes/handlePutOutcome.ts
@@ -68,7 +68,7 @@ export const handlePutOutcome = (hmppsAuthClient: HmppsAuthClient, addNotes = fa
       }
       if (outcomeCode) request.outcomeCode = outcomeCode
       await masClient.putContact(contactId, request)
-      if (enforcementActionCode?.length) {
+      if (enforcementActionCode?.length && !put) {
         const enforcementActionsRequest: EnforcementActionsRequest = {
           enforcementActions: enforcementActionCode.map(code => ({ code })),
         }


### PR DESCRIPTION
Fixes bug where the enforcement action was being re-posted when adding appointment notes