### PR TITLE
MAN-3010 fix bug where attended complied outcome was not posting notes

### DIFF
--- a/server/middleware/appointment-outcomes/handlePutOutcome.test.ts
+++ b/server/middleware/appointment-outcomes/handlePutOutcome.test.ts
@@ -208,7 +208,7 @@ describe('middleware/appointment-outcomes/handlePutOutcome', () => {
       time: start,
       sensitive: true,
       alert: false,
-      notes: '',
+      notes: 'Some added notes',
     }
     expect(putContactSpy).toHaveBeenCalledWith(contactId, expectedRequest)
     expect(postEnforcementActionsSpy).not.toHaveBeenCalled()

--- a/server/middleware/appointment-outcomes/handlePutOutcome.ts
+++ b/server/middleware/appointment-outcomes/handlePutOutcome.ts
@@ -39,7 +39,7 @@ export const handlePutOutcome = (hmppsAuthClient: HmppsAuthClient, addNotes = fa
       if (notePrepend) {
         notes = `${notePrepend}${notes ? `\n${notes}` : ''}`
       } else {
-        notes = appointmentSession?.notes
+        notes = appointmentSession?.notes || ''
       }
 
       if (notes) notes = handleQuotes(notes)

--- a/server/middleware/appointment-outcomes/handlePutOutcome.ts
+++ b/server/middleware/appointment-outcomes/handlePutOutcome.ts
@@ -38,8 +38,12 @@ export const handlePutOutcome = (hmppsAuthClient: HmppsAuthClient, addNotes = fa
       }
       if (notePrepend) {
         notes = `${notePrepend}${notes ? `\n${notes}` : ''}`
+      } else {
+        notes = appointmentSession?.notes
       }
+
       if (notes) notes = handleQuotes(notes)
+
       const sensitive = appointmentSession?.sensitivity === 'Yes'
       const token = await hmppsAuthClient.getSystemClientToken(res.locals.user.username)
       const masClient = new MasApiClient(token)
@@ -50,6 +54,7 @@ export const handlePutOutcome = (hmppsAuthClient: HmppsAuthClient, addNotes = fa
       ]
 
       // if outcome but no action, check the outcome type does not require an associated action 👇
+
       if (
         !put &&
         (!sensitivity ||


### PR DESCRIPTION
Fixes bug where updating an appointment outcome including notes with:
- no action or
- an action which was not breach or letter related
was not posting the notes to the backend.