### PR TITLE
MAN-3169 fix formatting of long action names in tag

### DIFF
--- a/assets/scss/application.scss
+++ b/assets/scss/application.scss
@@ -813,13 +813,17 @@ body.feature-disabled {
 
 .app-back-to-top__icon {
   display: inline-block;
-  width: .8em;
+  width: 0.8em;
   height: 1em;
   margin-top: -5px;
   margin-right: 10px;
   vertical-align: middle;
 }
 
-.arns-summary-card-expanded-badge-spacing{
+.arns-summary-card-expanded-badge-spacing {
   padding-bottom: 15px;
+}
+
+.govuk-tag--auto-width {
+  max-width: none !important;
 }

--- a/server/middleware/appointment-outcomes/getCurrentEnforcementAction.test.ts
+++ b/server/middleware/appointment-outcomes/getCurrentEnforcementAction.test.ts
@@ -8,10 +8,17 @@ const buildResponse = ({
   action = null,
   didTheyComply = false,
   enforcementAction = null,
-}: { action?: string; didTheyComply?: boolean; enforcementAction?: PersonAppointmentEnforcementAction } = {}) => {
+  reqUrl = '/case/X00001/appointments/appointment/1234/manage',
+}: {
+  action?: string
+  didTheyComply?: boolean
+  enforcementAction?: PersonAppointmentEnforcementAction
+  reqUrl?: string
+} = {}) => {
   const locals = {
     appointmentOutcome: {
       forename: 'James',
+      reqUrl,
       baseOutcomeUrl: '/base/outcome/url',
       appointment: {
         action,
@@ -114,6 +121,48 @@ describe('middleware/appointment-outcomes/getCurrentEnforcementAction', () => {
       evidenceWarning: 'James has until 23 May to submit evidence (0 days remaining)',
       link: '/base/outcome/url/attended-failed-to-comply',
       tagColour: 'GREEN',
+    })
+  })
+  it('should format the enforcement action title onto 2 lines if over 30 chars long and on manage page', () => {
+    const text = 'Decision pending response from person on probation'
+    const enforcementAction: PersonAppointmentEnforcementAction = {
+      code: 'EA12',
+      description: text,
+      responseByDate: '2026-05-23',
+    }
+    const res = buildResponse({ action: text, enforcementAction })
+    getCurrentEnforcementAction(req, res, nextSpy)
+    expect(res.locals.appointmentOutcome.currentEnforcementAction).toStrictEqual({
+      action: 'DECISION_PENDING_RESPONSE_FROM_PERSON_ON_PROBATION',
+      code: 'EA12',
+      description: 'Decision pending response<br>from person on probation',
+      evidenceDueDate: '23 May 2026',
+      evidenceWarning: 'James has until 23 May to submit evidence (0 days remaining)',
+      link: '/base/outcome/url/attended-failed-to-comply',
+      tagColour: 'YELLOW',
+    })
+  })
+  it('should not format the enforcement action title onto 2 lines if over 30 chars long and not on manage page', () => {
+    const text = 'Decision pending response from person on probation'
+    const enforcementAction: PersonAppointmentEnforcementAction = {
+      code: 'EA12',
+      description: text,
+      responseByDate: '2026-05-23',
+    }
+    const res = buildResponse({
+      action: text,
+      enforcementAction,
+      reqUrl: '/case/X000001/appointments/appointment/12345/outcome/update-enforcement-action',
+    })
+    getCurrentEnforcementAction(req, res, nextSpy)
+    expect(res.locals.appointmentOutcome.currentEnforcementAction).toStrictEqual({
+      action: 'DECISION_PENDING_RESPONSE_FROM_PERSON_ON_PROBATION',
+      code: 'EA12',
+      description: 'Decision pending response from person on probation',
+      evidenceDueDate: '23 May 2026',
+      evidenceWarning: 'James has until 23 May to submit evidence (0 days remaining)',
+      link: '/base/outcome/url/attended-failed-to-comply',
+      tagColour: 'YELLOW',
     })
   })
 })

--- a/server/middleware/appointment-outcomes/getCurrentEnforcementAction.ts
+++ b/server/middleware/appointment-outcomes/getCurrentEnforcementAction.ts
@@ -9,8 +9,8 @@ import { dateWithYear, toSentenceCase } from '../../utils'
 
 type Map = { [K in AppointmentEnforcementAction]?: TagColour }
 
-export const getCurrentEnforcementAction: Route<void> = (_req, res, next): void => {
-  const { forename, baseOutcomeUrl, appointmentSession } = res.locals
+export const getCurrentEnforcementAction: Route<void> = (req, res, next): void => {
+  const { forename, baseOutcomeUrl, appointmentSession, reqUrl } = res.locals
     .appointmentOutcome as AppointmentOutcomeProps<Activity>
   let tagColour: TagColour = 'YELLOW'
   let currentEnforcementAction: CurrentEnforcementAction = null
@@ -20,6 +20,7 @@ export const getCurrentEnforcementAction: Route<void> = (_req, res, next): void 
 
   if (enforcementAction) {
     const { description = '', responseByDate = null, code: actionCode } = enforcementAction
+    let formattedDescription = toSentenceCase(description)
     let action: AppointmentEnforcementAction = null
     if (enforcementAction.code) {
       action =
@@ -45,8 +46,15 @@ export const getCurrentEnforcementAction: Route<void> = (_req, res, next): void 
     }
     const outcomeType = appointmentSession?.outcome?.outcomeType
     const link = outcomeType ? outcomeRedirectMap(baseOutcomeUrl)?.[outcomeType] : baseOutcomeUrl
+    if (reqUrl.includes('/manage')) {
+      const words = formattedDescription.split(' ')
+      if (formattedDescription.length > 30) {
+        const half = Math.floor(words.length / 2)
+        formattedDescription = `${[...words.slice(0, half)].join(' ')}<br>${[...words.slice(half)].join(' ').toLowerCase()}`
+      }
+    }
     currentEnforcementAction = {
-      description: toSentenceCase(description),
+      description: formattedDescription,
       action,
       code: enforcementAction?.code,
       tagColour,

--- a/server/middleware/appointment-outcomes/getCurrentEnforcementAction.ts
+++ b/server/middleware/appointment-outcomes/getCurrentEnforcementAction.ts
@@ -12,7 +12,6 @@ type Map = { [K in AppointmentEnforcementAction]?: TagColour }
 export const getCurrentEnforcementAction: Route<void> = (req, res, next): void => {
   const { forename, baseOutcomeUrl, appointmentSession, reqUrl } = res.locals
     .appointmentOutcome as AppointmentOutcomeProps<Activity>
-  let tagColour: TagColour = 'YELLOW'
   let currentEnforcementAction: CurrentEnforcementAction = null
   let evidenceDueDate: string = null
   let evidenceWarning: string = null
@@ -22,7 +21,7 @@ export const getCurrentEnforcementAction: Route<void> = (req, res, next): void =
     const { description = '', responseByDate = null, code: actionCode } = enforcementAction
     let formattedDescription = toSentenceCase(description)
     let action: AppointmentEnforcementAction = null
-    if (enforcementAction.code) {
+    if (enforcementAction?.code) {
       action =
         (Object.entries(enforcementActionMap).find(
           ([_key, { code }]) => code === enforcementAction.code,
@@ -41,17 +40,15 @@ export const getCurrentEnforcementAction: Route<void> = (req, res, next): void =
       REFER_TO_OFFENDER_MANAGER: 'PURPLE',
       WITHDRAWAL_OF_WARNING: 'GREEN',
     }
-    if (map?.[action]) {
-      tagColour = map[action]
-    }
+
+    const tagColour: TagColour = map?.[action] || 'YELLOW'
+
     const outcomeType = appointmentSession?.outcome?.outcomeType
     const link = outcomeType ? outcomeRedirectMap(baseOutcomeUrl)?.[outcomeType] : baseOutcomeUrl
-    if (reqUrl.includes('/manage')) {
+    if (reqUrl.includes('/manage') && formattedDescription.length > 30) {
       const words = formattedDescription.split(' ')
-      if (formattedDescription.length > 30) {
-        const half = Math.floor(words.length / 2)
-        formattedDescription = `${[...words.slice(0, half)].join(' ')}<br>${[...words.slice(half)].join(' ').toLowerCase()}`
-      }
+      const half = Math.floor(words.length / 2)
+      formattedDescription = `${words.slice(0, half).join(' ')}<br>${words.slice(half).join(' ').toLowerCase()}`
     }
     currentEnforcementAction = {
       description: formattedDescription,

--- a/server/views/pages/appointment-outcomes/enforcement-action.njk
+++ b/server/views/pages/appointment-outcomes/enforcement-action.njk
@@ -8,7 +8,7 @@
     {{ govukInsetText({
   html: "The current enforcement status is: " + govukTag({
           text: appointmentOutcome.currentEnforcementAction.description,
-          classes: "govuk-tag--" + appointmentOutcome.currentEnforcementAction.tagColour | lower
+          classes: "govuk-tag--auto-width govuk-tag--" + appointmentOutcome.currentEnforcementAction.tagColour | lower
         })
 }) }}
   {% endif %}

--- a/server/views/pages/appointment-outcomes/update-enforcement-action.njk
+++ b/server/views/pages/appointment-outcomes/update-enforcement-action.njk
@@ -1,5 +1,5 @@
 {% extends "../_appointment-outcome-form.njk" %}
-{% set outcome = 'acceptable absence' if appointmentOutcome.appointment.acceptableAbsence == true else
+{% set outcome = 'acceptable absence' if appointmentOutcome.appointment.acceptableAbsence == true else 
   'failure to comply' %}
 {% set title = 'Update enforcement action for ' + appointmentOutcome.forename + '’s ' + outcome %}
 {% set pageTitle = makePageTitle({
@@ -12,7 +12,7 @@
     {{ govukInsetText({
   html: "The current enforcement status is: " + govukTag({
           text: appointmentOutcome.currentEnforcementAction.description,
-          classes: "govuk-tag--" + appointmentOutcome.currentEnforcementAction.tagColour | lower
+          classes: "govuk-tag--auto-width govuk-tag--" + appointmentOutcome.currentEnforcementAction.tagColour | lower
         })
 }) }}
   {% endif %}

--- a/server/views/pages/appointments/manage-appointment.njk
+++ b/server/views/pages/appointments/manage-appointment.njk
@@ -212,8 +212,8 @@ appointment.officer.name | fullName | convertToTitleCase) %}
       href: '/case/' + crn + '/appointments/appointment/' + contactId + '/outcome/update-enforcement-action',
       status: {
         tag: {
-          text: appointmentOutcome.currentEnforcementAction.description,
-          classes: "govuk-tag--" + appointmentOutcome.currentEnforcementAction.tagColour | lower
+          html: appointmentOutcome.currentEnforcementAction.description,
+          classes: "govuk-tag--auto-width govuk-tag--" + appointmentOutcome.currentEnforcementAction.tagColour | lower
         }
       }
     } if flags.enableNonCompliance and appointment.hasOutcome and appointment.action and not appointment.didTheyComply,


### PR DESCRIPTION
Formats long enforcement action titles onto 2 lines when displayed in tag on manage appt page