### PR TITLE
MAN-3121: Add Appointments in supervision packages filter

### DIFF
--- a/server/data/model/featureFlags.ts
+++ b/server/data/model/featureFlags.ts
@@ -24,5 +24,6 @@ export class FeatureFlags {
   enableESUPCheckinNewReview?: boolean = undefined
   enableESUPCheckinNewQuestions?: boolean = undefined
   enableSparksFilter?: boolean = undefined
+  enableSupervisionPackageFilter?: boolean = undefined
   enableRescheduleFutureAppointmentWithOutcome?: boolean = undefined
 }

--- a/server/middleware/filterActivityLog.test.ts
+++ b/server/middleware/filterActivityLog.test.ts
@@ -16,6 +16,7 @@ interface Args {
   compliance?: string | string[]
   category?: string | string[]
   sparks?: string | string[]
+  supervisionPackage?: string | string[]
   hideContact?: string | string[]
   clearFilterKey?: string
   clearFilterValue?: string
@@ -119,6 +120,7 @@ describe('/middleware/filterActivityLog()', () => {
         compliance: ['no outcome', 'complied', 'not complied'],
         category: categeoryList,
         sparks: [],
+        supervisionPackage: [],
         hideContact: ['hide NDelius system generated contacts'],
         dateFrom: '21/03/2025',
         dateTo: '22/03/2025',
@@ -173,6 +175,7 @@ describe('/middleware/filterActivityLog()', () => {
             },
           ],
           sparks: [],
+          supervisionPackage: [],
           hideContact: [
             {
               text: 'Hide NDelius system generated contacts',
@@ -187,6 +190,7 @@ describe('/middleware/filterActivityLog()', () => {
           checked: value === 'appointments',
         })),
         sparksOptions: [],
+        supervisionPackageOptions: [],
         hideContactOptions: hideContactsFilterOptions.map(({ text, value }) => ({
           text,
           value,
@@ -197,6 +201,7 @@ describe('/middleware/filterActivityLog()', () => {
         compliance: [req.query.compliance] as string[],
         category: [req.query.category] as string[],
         sparks: [],
+        supervisionPackage: [],
         hideContact: [req.query.hideContact] as string[],
         dateFrom: req.query.dateFrom as string,
         dateTo: req.query.dateTo as string,
@@ -265,6 +270,61 @@ describe('/middleware/filterActivityLog()', () => {
     })
   })
 
+  describe('enableSupervisionPackageFilter feature flag is enabled', () => {
+    const flaggedRes = {
+      locals: {
+        user: { username: 'user-1' },
+        flags: { enableSupervisionPackageFilter: true },
+      },
+      redirect: jest.fn().mockReturnThis(),
+    } as unknown as AppResponse
+    const req = getRequest({
+      submit: true,
+      keywords: '',
+      dateFrom: '',
+      dateTo: '',
+      compliance: 'complied',
+      category: 'appointments',
+      supervisionPackage: 'appointments in supervision package',
+      hideContact: 'hide NDelius system generated contacts',
+    })
+    beforeEach(() => {
+      filterActivityLog(req, flaggedRes, nextSpy)
+    })
+    it('should expose the supervision package filter in its own supervisionPackageOptions checkbox group', () => {
+      expect(flaggedRes.locals.filters.supervisionPackageOptions).toEqual([
+        {
+          text: 'Show appointments in supervision package',
+          value: 'appointments in supervision package',
+          checked: true,
+        },
+      ])
+    })
+    it('should show the supervision package filter as its own selected filter tag', () => {
+      expect(flaggedRes.locals.filters.selectedFilterItems.supervisionPackage).toEqual([
+        {
+          text: 'Show appointments in supervision package',
+          href: `/case/${crn}/activity-log?clearFilterKey=supervisionPackage&clearFilterValue=appointments%20in%20supervision%20package`,
+        },
+      ])
+    })
+  })
+
+  describe('Selected supervision package filter tag is clicked', () => {
+    const req = getRequest({
+      submit: true,
+      supervisionPackage: 'appointments in supervision package',
+      clearFilterKey: 'supervisionPackage',
+      clearFilterValue: 'appointments in supervision package',
+    })
+    beforeEach(() => {
+      filterActivityLog(req, res, nextSpy)
+    })
+    it('should remove the cleared value from the session', () => {
+      expect(req.session.activityLogFilters.supervisionPackage).toEqual([])
+    })
+  })
+
   describe('a session category value is not present in the current options (e.g. flag turned off after selecting SPARKS)', () => {
     const req = getRequest({
       submit: true,
@@ -326,6 +386,7 @@ describe('/middleware/filterActivityLog()', () => {
             })),
           ],
           sparks: [],
+          supervisionPackage: [],
           hideContact: [
             ...(query.hideContact as string[]).map((item, i) => ({
               text: hideContactsFilterOptions[i].text,
@@ -342,12 +403,14 @@ describe('/middleware/filterActivityLog()', () => {
         complianceOptions: filterOptions.map(({ text, value }) => ({ text, value, checked: true })),
         categoryOptions: categoryFilterOptions.map(({ text, value }) => ({ text, value, checked: true })),
         sparksOptions: [],
+        supervisionPackageOptions: [],
         hideContactOptions: hideContactsFilterOptions.map(({ text, value }) => ({ text, value, checked: true })),
         baseUrl: `/case/${crn}/activity-log`,
         keywords: req.query.keywords as string,
         compliance: req.query.compliance as string[],
         category: req.query.category as string[],
         sparks: [],
+        supervisionPackage: [],
         hideContact: req.query.hideContact as string[],
         dateFrom: req.query.dateFrom as string,
         dateTo: req.query.dateTo as string,
@@ -418,6 +481,7 @@ describe('/middleware/filterActivityLog()', () => {
             })),
           ],
           sparks: [],
+          supervisionPackage: [],
           hideContact: [
             ...(query.hideContact as string[]).map((item, i) => ({
               text: hideContactsFilterOptions[i].text,
@@ -428,12 +492,14 @@ describe('/middleware/filterActivityLog()', () => {
         complianceOptions: filterOptions.map(({ text, value }) => ({ text, value, checked: true })),
         categoryOptions: categoryFilterOptions.map(({ text, value }) => ({ text, value, checked: true })),
         sparksOptions: [],
+        supervisionPackageOptions: [],
         hideContactOptions: hideContactsFilterOptions.map(({ text, value }) => ({ text, value, checked: true })),
         baseUrl: `/case/${crn}/activity-log`,
         keywords: req.query.keywords as string,
         compliance: req.query.compliance as string[],
         category: req.query.category as string[],
         sparks: [],
+        supervisionPackage: [],
         hideContact: req.query.hideContact as string[],
         dateFrom: '',
         dateTo: '',
@@ -476,6 +542,7 @@ describe('/middleware/filterActivityLog()', () => {
             },
           ],
           sparks: [],
+          supervisionPackage: [],
           hideContact: [
             {
               text: 'Hide NDelius system generated contacts',
@@ -502,6 +569,7 @@ describe('/middleware/filterActivityLog()', () => {
           checked: value === 'appointments',
         })),
         sparksOptions: [],
+        supervisionPackageOptions: [],
         hideContactOptions: hideContactsFilterOptions.map(({ text, value }) => ({
           text,
           value,
@@ -512,6 +580,7 @@ describe('/middleware/filterActivityLog()', () => {
         compliance: ['not complied'],
         category: ['appointments'],
         sparks: [],
+        supervisionPackage: [],
         hideContact: ['hide NDelius system generated contacts'],
         dateFrom: '20/03/2025',
         dateTo: '23/03/2025',

--- a/server/middleware/filterActivityLog.ts
+++ b/server/middleware/filterActivityLog.ts
@@ -6,6 +6,7 @@ import { Route } from '../@types'
 import {
   categoryFilterOptions,
   sparksCategoryFilterOption,
+  supervisionPackageCategoryFilterOption,
   filterOptions as complianceFilterOptions,
   hideContactsFilterOptions,
 } from '../properties'
@@ -20,7 +21,7 @@ export const filterActivityLog: Route<void> = (req, res, next): void => {
   const { clearFilterKey, clearFilterValue } = req.query
   const view = req?.query?.view ?? req?.body?.view
   const { crn } = req.params as Record<string, string>
-  const { keywords, dateFrom, dateTo, compliance, category, sparks, hideContact } = setSession()
+  const { keywords, dateFrom, dateTo, compliance, category, sparks, supervisionPackage, hideContact } = setSession()
   const errorMessages = req?.session?.errorMessages
 
   function setSession() {
@@ -31,11 +32,15 @@ export const filterActivityLog: Route<void> = (req, res, next): void => {
       const complianceFilters: Array<string> = req.body.compliance ? [req.body.compliance].flat() : []
       const categoryFilters: Array<string> = req.body.category ? [req.body.category].flat() : []
       const sparksFilters: Array<string> = req.body.sparks ? [req.body.sparks].flat() : []
+      const supervisionPackageFilters: Array<string> = req.body.supervisionPackage
+        ? [req.body.supervisionPackage].flat()
+        : []
       const hideContactFilters: Array<string> = req.body.hideContact ? [req.body.hideContact].flat() : []
       req.session.activityLogFilters = req.body as ActivityLogFilters
       req.session.activityLogFilters.compliance = complianceFilters
       req.session.activityLogFilters.category = categoryFilters
       req.session.activityLogFilters.sparks = sparksFilters
+      req.session.activityLogFilters.supervisionPackage = supervisionPackageFilters
       req.session.activityLogFilters.hideContact = hideContactFilters
       req.session.activityLogFilters.crn = crn
     }
@@ -49,6 +54,7 @@ export const filterActivityLog: Route<void> = (req, res, next): void => {
       compliance: req.session?.activityLogFilters?.compliance ?? [],
       category: req.session?.activityLogFilters?.category ?? [],
       sparks: req.session?.activityLogFilters?.sparks ?? [],
+      supervisionPackage: req.session?.activityLogFilters?.supervisionPackage ?? [],
       hideContact: req.session?.activityLogFilters?.hideContact ?? [],
     }
   }
@@ -70,6 +76,10 @@ export const filterActivityLog: Route<void> = (req, res, next): void => {
       req.session.activityLogFilters.sparks = req.session.activityLogFilters.sparks.filter(
         (value: string) => value !== clearFilterValue,
       )
+    } else if (clearFilterKey === 'supervisionPackage') {
+      req.session.activityLogFilters.supervisionPackage = req.session.activityLogFilters.supervisionPackage.filter(
+        (value: string) => value !== clearFilterValue,
+      )
     } else if (clearFilterKey === 'hideContact') {
       req.session.activityLogFilters.hideContact = req.session.activityLogFilters.hideContact.filter(
         (value: string) => value !== clearFilterValue,
@@ -85,6 +95,9 @@ export const filterActivityLog: Route<void> = (req, res, next): void => {
     : categoryFilterOptions
   const sparksOptionsSource = sparksEnabled ? [sparksCategoryFilterOption] : []
 
+  const supervisionPackageEnabled = res.locals.flags?.enableSupervisionPackageFilter === true
+  const supervisionPackageOptionsSource = supervisionPackageEnabled ? [supervisionPackageCategoryFilterOption] : []
+
   const baseUrl = `/case/${crn}/activity-log`
   const filters: ActivityLogFilters = {
     keywords,
@@ -93,10 +106,11 @@ export const filterActivityLog: Route<void> = (req, res, next): void => {
     compliance,
     category,
     sparks,
+    supervisionPackage,
     hideContact,
   }
 
-  const keysWithClearValue = ['compliance', 'category', 'sparks', 'hideContact']
+  const keysWithClearValue = ['compliance', 'category', 'sparks', 'supervisionPackage', 'hideContact']
   const filterHref = (key: string, value: string): string => {
     const base = keysWithClearValue.includes(key)
       ? `${baseUrl}?clearFilterKey=${key}&clearFilterValue=${encodeURIComponent(value)}`
@@ -129,6 +143,14 @@ export const filterActivityLog: Route<void> = (req, res, next): void => {
             if (sparksOption) {
               value.push({
                 text: sparksOption.text,
+                href: filterHref(filterKey, text),
+              })
+            }
+          } else if (filterKey === 'supervisionPackage') {
+            const supervisionPackageOption = supervisionPackageOptionsSource.find(option => option.value === text)
+            if (supervisionPackageOption) {
+              value.push({
+                text: supervisionPackageOption.text,
                 href: filterHref(filterKey, text),
               })
             }
@@ -170,6 +192,12 @@ export const filterActivityLog: Route<void> = (req, res, next): void => {
     checked: filters.sparks.includes(value),
   }))
 
+  const supervisionPackageOptions: Option[] = supervisionPackageOptionsSource.map(({ text, value }) => ({
+    text,
+    value,
+    checked: filters.supervisionPackage.includes(value),
+  }))
+
   const hideContactOptions: Option[] = hideContactsFilterOptions.map(({ text, value }) => ({
     text,
     value,
@@ -184,12 +212,14 @@ export const filterActivityLog: Route<void> = (req, res, next): void => {
     complianceOptions,
     categoryOptions,
     sparksOptions,
+    supervisionPackageOptions,
     hideContactOptions,
     baseUrl,
     keywords: filters.keywords,
     compliance: filters.compliance,
     category: filters.category,
     sparks: filters.sparks,
+    supervisionPackage: filters.supervisionPackage,
     dateFrom: filters.dateFrom,
     dateTo: filters.dateTo,
     hideContact: filters.hideContact,

--- a/server/middleware/getPersonActivity.test.ts
+++ b/server/middleware/getPersonActivity.test.ts
@@ -7,7 +7,12 @@ import TierApiClient from '../data/tierApiClient'
 import { toIsoDateFromPicker } from '../utils'
 import { ActivityLogRequestBody } from '../models/ActivityLog'
 import { Document } from '../data/model/personalDetails'
-import { APPOINTMENTS_CODES, SPARKS_FILTER_VALUE, ACTIVITY_LOG_PAGE_SIZE } from '../properties'
+import {
+  APPOINTMENTS_CODES,
+  SPARKS_FILTER_VALUE,
+  SUPERVISION_PACKAGE_FILTER_VALUE,
+  ACTIVITY_LOG_PAGE_SIZE,
+} from '../properties'
 
 jest.mock('../data/masApiClient')
 jest.mock('../data/hmppsAuthClient')
@@ -154,6 +159,7 @@ describe('/middleware/getPersonActivity', () => {
       complianceOptions: [],
       categoryOptions: [],
       sparksOptions: [],
+      supervisionPackageOptions: [],
       hideContactOptions: [],
       selectedFilterItems: {},
       baseUrl: '',
@@ -200,6 +206,7 @@ describe('/middleware/getPersonActivity', () => {
       complianceOptions: [],
       categoryOptions: [],
       sparksOptions: [],
+      supervisionPackageOptions: [],
       hideContactOptions: [],
       selectedFilterItems: {},
       baseUrl: '',
@@ -232,6 +239,7 @@ describe('/middleware/getPersonActivity', () => {
       complianceOptions: [],
       categoryOptions: [],
       sparksOptions: [],
+      supervisionPackageOptions: [],
       hideContactOptions: [],
       selectedFilterItems: {},
       baseUrl: '',
@@ -264,6 +272,108 @@ describe('/middleware/getPersonActivity', () => {
       complianceOptions: [],
       categoryOptions: [],
       sparksOptions: [],
+      supervisionPackageOptions: [],
+      hideContactOptions: [],
+      selectedFilterItems: {},
+      baseUrl: '',
+      query: { ...filterVals },
+      maxDate: '21/1/2025',
+      crn,
+    }
+
+    const hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
+
+    await getPersonActivity(req, res, hmppsAuthClient)
+    expect(masSpy).toHaveBeenCalledWith(
+      crn,
+      expect.objectContaining({ filters: ['complied'], typeCodes: [] }),
+      '0',
+      String(ACTIVITY_LOG_PAGE_SIZE),
+    )
+  })
+
+  it('should map the supervision package filter to the request body filters (not typeCodes) when enableSupervisionPackageFilter is enabled', async () => {
+    req.params = { crn }
+    req.query = { page: '0' }
+    res.locals.flags = { enableSupervisionPackageFilter: true }
+    res.locals.filters = {
+      ...filterVals,
+      compliance: [],
+      category: [],
+      supervisionPackage: ['appointments in supervision package'],
+      complianceOptions: [],
+      categoryOptions: [],
+      sparksOptions: [],
+      supervisionPackageOptions: [],
+      hideContactOptions: [],
+      selectedFilterItems: {},
+      baseUrl: '',
+      query: { ...filterVals },
+      maxDate: '21/1/2025',
+      crn,
+    }
+
+    const hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
+
+    await getPersonActivity(req, res, hmppsAuthClient)
+    expect(masSpy).toHaveBeenCalledWith(
+      crn,
+      expect.objectContaining({ filters: [SUPERVISION_PACKAGE_FILTER_VALUE], typeCodes: [] }),
+      '0',
+      String(ACTIVITY_LOG_PAGE_SIZE),
+    )
+    res.locals.flags = {}
+  })
+
+  it('should keep category filters in typeCodes while routing the supervision package filter to filters', async () => {
+    req.params = { crn }
+    req.query = { page: '0' }
+    res.locals.flags = { enableSupervisionPackageFilter: true }
+    res.locals.filters = {
+      ...filterVals,
+      compliance: ['complied'],
+      category: ['appointments'],
+      supervisionPackage: ['appointments in supervision package'],
+      complianceOptions: [],
+      categoryOptions: [],
+      sparksOptions: [],
+      supervisionPackageOptions: [],
+      hideContactOptions: [],
+      selectedFilterItems: {},
+      baseUrl: '',
+      query: { ...filterVals },
+      maxDate: '21/1/2025',
+      crn,
+    }
+
+    const hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
+
+    await getPersonActivity(req, res, hmppsAuthClient)
+    expect(masSpy).toHaveBeenCalledWith(
+      crn,
+      expect.objectContaining({
+        filters: ['complied', SUPERVISION_PACKAGE_FILTER_VALUE],
+        typeCodes: APPOINTMENTS_CODES,
+      }),
+      '0',
+      String(ACTIVITY_LOG_PAGE_SIZE),
+    )
+    res.locals.flags = {}
+  })
+
+  it('should not apply the supervision package filter when enableSupervisionPackageFilter is disabled, even if the session holds a value', async () => {
+    req.params = { crn }
+    req.query = { page: '0' }
+    res.locals.flags = {}
+    res.locals.filters = {
+      ...filterVals,
+      compliance: ['complied'],
+      category: [],
+      supervisionPackage: ['appointments in supervision package'],
+      complianceOptions: [],
+      categoryOptions: [],
+      sparksOptions: [],
+      supervisionPackageOptions: [],
       hideContactOptions: [],
       selectedFilterItems: {},
       baseUrl: '',

--- a/server/middleware/getPersonActivity.ts
+++ b/server/middleware/getPersonActivity.ts
@@ -6,7 +6,12 @@ import TierApiClient, { TierCalculation } from '../data/tierApiClient'
 import { toIsoDateFromPicker, toCamelCase } from '../utils'
 import { AppResponse } from '../models/Locals'
 import { ActivityLogRequestBody, SelectedFilterItem } from '../models/ActivityLog'
-import { categoryFilterOptions, sparksCategoryFilterOption, ACTIVITY_LOG_PAGE_SIZE } from '../properties'
+import {
+  categoryFilterOptions,
+  sparksCategoryFilterOption,
+  supervisionPackageCategoryFilterOption,
+  ACTIVITY_LOG_PAGE_SIZE,
+} from '../properties'
 
 export const getPersonActivity = async (
   req: Request,
@@ -15,7 +20,7 @@ export const getPersonActivity = async (
 ): Promise<[TierCalculation, PersonActivity]> => {
   const { filters } = res.locals
   const { params, query } = req
-  const { keywords, dateFrom, dateTo, compliance, category, sparks, hideContact } = filters
+  const { keywords, dateFrom, dateTo, compliance, category, sparks, supervisionPackage, hideContact } = filters
   const { crn } = params as Record<string, string>
   const { page = '0' } = query
   const token = await hmppsAuthClient.getSystemClientToken(res.locals.user.username)
@@ -38,6 +43,15 @@ export const getPersonActivity = async (
     sparksFilters.push(...sparksCategoryFilterOption.codes)
   }
 
+  const supervisionPackageFilters: string[] = []
+  if (
+    res.locals.flags?.enableSupervisionPackageFilter &&
+    Array.isArray(supervisionPackage) &&
+    supervisionPackage.includes(supervisionPackageCategoryFilterOption.value)
+  ) {
+    supervisionPackageFilters.push(...supervisionPackageCategoryFilterOption.codes)
+  }
+
   const formatCompliance = (): Array<string> => {
     const complianceArray: string[] = []
 
@@ -54,7 +68,7 @@ export const getPersonActivity = async (
     keywords,
     dateFrom: dateFrom ? toIsoDateFromPicker(dateFrom) : '',
     dateTo: dateTo ? toIsoDateFromPicker(dateTo) : '',
-    filters: [...formatCompliance(), ...sparksFilters],
+    filters: [...formatCompliance(), ...sparksFilters, ...supervisionPackageFilters],
     includeSystemGenerated: hideContact?.length === 0,
     typeCodes: combinedCategoryCodes,
   }

--- a/server/models/ActivityLog.ts
+++ b/server/models/ActivityLog.ts
@@ -7,6 +7,7 @@ export interface ActivityLogFilters {
   compliance: Array<string> | string
   category: string[]
   sparks?: string[]
+  supervisionPackage?: string[]
   clearFilterKey?: string
   clearFilterValue?: string
   hideContact?: Array<string>
@@ -31,6 +32,7 @@ export interface ActivityLogFiltersResponse extends ActivityLogFilters {
   complianceOptions: Option[]
   categoryOptions: Option[]
   sparksOptions: Option[]
+  supervisionPackageOptions: Option[]
   hideContactOptions: Option[]
   baseUrl: string
   maxDate: string

--- a/server/properties/filterOptions.ts
+++ b/server/properties/filterOptions.ts
@@ -566,6 +566,14 @@ export const sparksCategoryFilterOption = {
   codes: [SPARKS_FILTER_VALUE],
 }
 
+export const SUPERVISION_PACKAGE_FILTER_VALUE = 'supervisionPackage'
+
+export const supervisionPackageCategoryFilterOption = {
+  text: 'Show appointments in supervision package',
+  value: 'appointments in supervision package',
+  codes: [SUPERVISION_PACKAGE_FILTER_VALUE],
+}
+
 export const categoryFilterOptions = [
   { text: 'Appointments', value: 'appointments', codes: APPOINTMENTS_CODES },
   { text: 'Approved Premises', value: 'Approved Premises', codes: APPROVED_PREMISES_CODES },

--- a/server/views/pages/contact-log/_filters.njk
+++ b/server/views/pages/contact-log/_filters.njk
@@ -108,6 +108,26 @@
   }) }}
   {% endif %}
 
+  {% if filters.supervisionPackageOptions.length %}
+  {{ govukCheckboxes({
+    idPrefix: 'supervisionPackage',
+    name: 'supervisionPackage',
+    classes: "govuk-checkboxes--small",
+    fieldset: {
+      legend: {
+        text: 'Appointments in supervision package',
+        classes: 'govuk-fieldset__legend--s'
+      }
+    },
+    formGroup: {
+      attributes: {
+        'data-qa': 'supervisionPackage'
+      }
+    },
+    items: filters.supervisionPackageOptions
+  }) }}
+  {% endif %}
+
   {{ govukCheckboxes({
     idPrefix: 'category',
     name: 'category',
@@ -181,6 +201,15 @@
     }), filterCategories) %}
 {% endif %}
 
+{% if filters.selectedFilterItems.supervisionPackage.length %}
+    {% set filterCategories = (filterCategories.push({
+        heading: {
+            text: 'Appointments in supervision package'
+        },
+        items: filters.selectedFilterItems.supervisionPackage
+    }), filterCategories) %}
+{% endif %}
+
 
 <div class="govuk-grid-column-one-third contact-activity__filter govuk-!-padding-bottom-4">
     <form role="region" aria-label="Filters" method="post" autocomplete="off" data-qa="filter-form" action="{{ baseUrl }}">
@@ -234,7 +263,7 @@
       href: '/case/' + crn + '/activity-log' + clearLink
     },
     categories: filterCategories
-  } if filters.selectedFilterItems.keywords.length or filters.selectedFilterItems.dateRange.length or filters.selectedFilterItems.compliance.length or filters.selectedFilterItems.category.length or filters.selectedFilterItems.sparks.length,
+  } if filters.selectedFilterItems.keywords.length or filters.selectedFilterItems.dateRange.length or filters.selectedFilterItems.compliance.length or filters.selectedFilterItems.category.length or filters.selectedFilterItems.sparks.length or filters.selectedFilterItems.supervisionPackage.length,
   optionsHtml: filterOptionsHtml
 }) }}
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">

--- a/server/views/pages/contact-log/_filters.njk
+++ b/server/views/pages/contact-log/_filters.njk
@@ -115,7 +115,7 @@
     classes: "govuk-checkboxes--small",
     fieldset: {
       legend: {
-        text: 'Appointments in supervision package',
+        text: 'Supervision package appointments filter',
         classes: 'govuk-fieldset__legend--s'
       }
     },
@@ -204,7 +204,7 @@
 {% if filters.selectedFilterItems.supervisionPackage.length %}
     {% set filterCategories = (filterCategories.push({
         heading: {
-            text: 'Appointments in supervision package'
+            text: 'Supervision package appointments filter'
         },
         items: filters.selectedFilterItems.supervisionPackage
     }), filterCategories) %}


### PR DESCRIPTION
## Summary
- Adds a new **Supervision package appointments filter** to the activity log (contact log) page, 
- The filter is gated behind a new `enableSupervisionPackageFilter` feature flag.

<img width="390" height="862" alt="image" src="https://github.com/user-attachments/assets/62373173-5372-4c58-90cf-09e4c901128e" />
