### PR TITLE
MAN-3169 fix formatting of long action names in tag

### DIFF
--- a/server/views/pages/appointments/manage-appointment.njk
+++ b/server/views/pages/appointments/manage-appointment.njk
@@ -198,7 +198,7 @@ appointment.officer.name | fullName | convertToTitleCase) %}
       status: {
         tag: {
           text: compliedStatus if not flags.enableNonCompliance else appointmentOutcome.currentOutcome.status,
-          classes: "govuk-tag--" + (compliedTagColor if not flags.enableNonCompliance else appointmentOutcome.currentOutcome.tagColour | lower)
+          classes: "govuk-tag--auto-width govuk-tag--" + (compliedTagColor if not flags.enableNonCompliance else appointmentOutcome.currentOutcome.tagColour | lower)
         }
       }
     },


### PR DESCRIPTION
Further change to apply action tag width formatting fix to outcome listing on manage page