### PR TITLE
MAN-3121: Change how the SPARKS and Supervision-package activity-log …

### DIFF
--- a/server/controllers/activityLog.test.ts
+++ b/server/controllers/activityLog.test.ts
@@ -117,6 +117,8 @@ describe('/controllers/activityLogController', () => {
         dateFrom: '',
         dateTo: '',
         filters: [] as string[],
+        filterBySparksContacts: false,
+        filterBySupervisionPackageContacts: false,
         includeSystemGenerated: false,
         typeCodes: [] as string[],
       }

--- a/server/middleware/getPersonActivity.test.ts
+++ b/server/middleware/getPersonActivity.test.ts
@@ -390,4 +390,43 @@ describe('/middleware/getPersonActivity', () => {
       String(ACTIVITY_LOG_PAGE_SIZE),
     )
   })
+
+  it('should set both filterBySparksContacts and filterBySupervisionPackageContacts to true when both flags are enabled and both values are selected', async () => {
+    req.params = { crn }
+    req.query = { page: '0' }
+    res.locals.flags = { enableSparksFilter: true, enableSupervisionPackageFilter: true }
+    res.locals.filters = {
+      ...filterVals,
+      compliance: [],
+      category: [],
+      sparks: ['appointments with sparks activity'],
+      supervisionPackage: ['appointments in supervision package'],
+      complianceOptions: [],
+      categoryOptions: [],
+      sparksOptions: [],
+      supervisionPackageOptions: [],
+      hideContactOptions: [],
+      selectedFilterItems: {},
+      baseUrl: '',
+      query: { ...filterVals },
+      maxDate: '21/1/2025',
+      crn,
+    }
+
+    const hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
+
+    await getPersonActivity(req, res, hmppsAuthClient)
+    expect(masSpy).toHaveBeenCalledWith(
+      crn,
+      expect.objectContaining({
+        filters: [],
+        filterBySparksContacts: true,
+        filterBySupervisionPackageContacts: true,
+        typeCodes: [],
+      }),
+      '0',
+      String(ACTIVITY_LOG_PAGE_SIZE),
+    )
+    res.locals.flags = {}
+  })
 })

--- a/server/middleware/getPersonActivity.test.ts
+++ b/server/middleware/getPersonActivity.test.ts
@@ -7,12 +7,7 @@ import TierApiClient from '../data/tierApiClient'
 import { toIsoDateFromPicker } from '../utils'
 import { ActivityLogRequestBody } from '../models/ActivityLog'
 import { Document } from '../data/model/personalDetails'
-import {
-  APPOINTMENTS_CODES,
-  SPARKS_FILTER_VALUE,
-  SUPERVISION_PACKAGE_FILTER_VALUE,
-  ACTIVITY_LOG_PAGE_SIZE,
-} from '../properties'
+import { APPOINTMENTS_CODES, ACTIVITY_LOG_PAGE_SIZE } from '../properties'
 
 jest.mock('../data/masApiClient')
 jest.mock('../data/hmppsAuthClient')
@@ -183,6 +178,8 @@ describe('/middleware/getPersonActivity', () => {
       dateFrom: toIsoDateFromPicker(filterVals.dateFrom),
       dateTo: toIsoDateFromPicker(filterVals.dateTo),
       filters: ['complied', 'notComplied'],
+      filterBySparksContacts: false,
+      filterBySupervisionPackageContacts: false,
       includeSystemGenerated: false,
       typeCodes: APPOINTMENTS_CODES,
     }
@@ -194,7 +191,7 @@ describe('/middleware/getPersonActivity', () => {
     expect(tierCalculation).toEqual(mockTierCalculationResponse)
   })
 
-  it('should map the SPARKS filter to the request body filters (not typeCodes) when enableSparksFilter is enabled', async () => {
+  it('should set filterBySparksContacts to true (not typeCodes or filters) when enableSparksFilter is enabled', async () => {
     req.params = { crn }
     req.query = { page: '0' }
     res.locals.flags = { enableSparksFilter: true }
@@ -220,14 +217,14 @@ describe('/middleware/getPersonActivity', () => {
     await getPersonActivity(req, res, hmppsAuthClient)
     expect(masSpy).toHaveBeenCalledWith(
       crn,
-      expect.objectContaining({ filters: [SPARKS_FILTER_VALUE], typeCodes: [] }),
+      expect.objectContaining({ filters: [], filterBySparksContacts: true, typeCodes: [] }),
       '0',
       String(ACTIVITY_LOG_PAGE_SIZE),
     )
     res.locals.flags = {}
   })
 
-  it('should keep category filters in typeCodes while routing SPARKS to filters', async () => {
+  it('should keep category filters in typeCodes while setting filterBySparksContacts to true', async () => {
     req.params = { crn }
     req.query = { page: '0' }
     res.locals.flags = { enableSparksFilter: true }
@@ -253,7 +250,7 @@ describe('/middleware/getPersonActivity', () => {
     await getPersonActivity(req, res, hmppsAuthClient)
     expect(masSpy).toHaveBeenCalledWith(
       crn,
-      expect.objectContaining({ filters: ['complied', SPARKS_FILTER_VALUE], typeCodes: APPOINTMENTS_CODES }),
+      expect.objectContaining({ filters: ['complied'], filterBySparksContacts: true, typeCodes: APPOINTMENTS_CODES }),
       '0',
       String(ACTIVITY_LOG_PAGE_SIZE),
     )
@@ -286,13 +283,13 @@ describe('/middleware/getPersonActivity', () => {
     await getPersonActivity(req, res, hmppsAuthClient)
     expect(masSpy).toHaveBeenCalledWith(
       crn,
-      expect.objectContaining({ filters: ['complied'], typeCodes: [] }),
+      expect.objectContaining({ filters: ['complied'], filterBySparksContacts: false, typeCodes: [] }),
       '0',
       String(ACTIVITY_LOG_PAGE_SIZE),
     )
   })
 
-  it('should map the supervision package filter to the request body filters (not typeCodes) when enableSupervisionPackageFilter is enabled', async () => {
+  it('should set filterBySupervisionPackageContacts to true (not typeCodes or filters) when enableSupervisionPackageFilter is enabled', async () => {
     req.params = { crn }
     req.query = { page: '0' }
     res.locals.flags = { enableSupervisionPackageFilter: true }
@@ -318,14 +315,14 @@ describe('/middleware/getPersonActivity', () => {
     await getPersonActivity(req, res, hmppsAuthClient)
     expect(masSpy).toHaveBeenCalledWith(
       crn,
-      expect.objectContaining({ filters: [SUPERVISION_PACKAGE_FILTER_VALUE], typeCodes: [] }),
+      expect.objectContaining({ filters: [], filterBySupervisionPackageContacts: true, typeCodes: [] }),
       '0',
       String(ACTIVITY_LOG_PAGE_SIZE),
     )
     res.locals.flags = {}
   })
 
-  it('should keep category filters in typeCodes while routing the supervision package filter to filters', async () => {
+  it('should keep category filters in typeCodes while setting filterBySupervisionPackageContacts to true', async () => {
     req.params = { crn }
     req.query = { page: '0' }
     res.locals.flags = { enableSupervisionPackageFilter: true }
@@ -352,7 +349,8 @@ describe('/middleware/getPersonActivity', () => {
     expect(masSpy).toHaveBeenCalledWith(
       crn,
       expect.objectContaining({
-        filters: ['complied', SUPERVISION_PACKAGE_FILTER_VALUE],
+        filters: ['complied'],
+        filterBySupervisionPackageContacts: true,
         typeCodes: APPOINTMENTS_CODES,
       }),
       '0',
@@ -387,7 +385,7 @@ describe('/middleware/getPersonActivity', () => {
     await getPersonActivity(req, res, hmppsAuthClient)
     expect(masSpy).toHaveBeenCalledWith(
       crn,
-      expect.objectContaining({ filters: ['complied'], typeCodes: [] }),
+      expect.objectContaining({ filters: ['complied'], filterBySupervisionPackageContacts: false, typeCodes: [] }),
       '0',
       String(ACTIVITY_LOG_PAGE_SIZE),
     )

--- a/server/middleware/getPersonActivity.ts
+++ b/server/middleware/getPersonActivity.ts
@@ -34,23 +34,15 @@ export const getPersonActivity = async (
     }
   }
 
-  const sparksFilters: string[] = []
-  if (
-    res.locals.flags?.enableSparksFilter &&
+  const filterBySparksContacts =
+    res.locals.flags?.enableSparksFilter === true &&
     Array.isArray(sparks) &&
     sparks.includes(sparksCategoryFilterOption.value)
-  ) {
-    sparksFilters.push(...sparksCategoryFilterOption.codes)
-  }
 
-  const supervisionPackageFilters: string[] = []
-  if (
-    res.locals.flags?.enableSupervisionPackageFilter &&
+  const filterBySupervisionPackageContacts =
+    res.locals.flags?.enableSupervisionPackageFilter === true &&
     Array.isArray(supervisionPackage) &&
     supervisionPackage.includes(supervisionPackageCategoryFilterOption.value)
-  ) {
-    supervisionPackageFilters.push(...supervisionPackageCategoryFilterOption.codes)
-  }
 
   const formatCompliance = (): Array<string> => {
     const complianceArray: string[] = []
@@ -68,7 +60,9 @@ export const getPersonActivity = async (
     keywords,
     dateFrom: dateFrom ? toIsoDateFromPicker(dateFrom) : '',
     dateTo: dateTo ? toIsoDateFromPicker(dateTo) : '',
-    filters: [...formatCompliance(), ...sparksFilters, ...supervisionPackageFilters],
+    filters: [...formatCompliance()],
+    filterBySparksContacts,
+    filterBySupervisionPackageContacts,
     includeSystemGenerated: hideContact?.length === 0,
     typeCodes: combinedCategoryCodes,
   }

--- a/server/models/ActivityLog.ts
+++ b/server/models/ActivityLog.ts
@@ -18,6 +18,8 @@ export interface ActivityLogRequestBody {
   dateFrom: string
   dateTo: string
   filters: string[]
+  filterBySparksContacts?: boolean
+  filterBySupervisionPackageContacts?: boolean
   includeSystemGenerated?: boolean
   typeCodes: string[]
 }

--- a/server/properties/filterOptions.ts
+++ b/server/properties/filterOptions.ts
@@ -558,20 +558,14 @@ export const ENFORCEMENT_CODES: string[] = [
   'C145',
 ]
 
-export const SPARKS_FILTER_VALUE = 'sparks'
-
 export const sparksCategoryFilterOption = {
   text: 'Show appointments with SPARKS activity',
   value: 'appointments with sparks activity',
-  codes: [SPARKS_FILTER_VALUE],
 }
-
-export const SUPERVISION_PACKAGE_FILTER_VALUE = 'supervisionPackage'
 
 export const supervisionPackageCategoryFilterOption = {
   text: 'Show appointments in supervision package',
   value: 'appointments in supervision package',
-  codes: [SUPERVISION_PACKAGE_FILTER_VALUE],
 }
 
 export const categoryFilterOptions = [

--- a/wiremock/mappings/X000001-activity-log.json
+++ b/wiremock/mappings/X000001-activity-log.json
@@ -512,7 +512,7 @@
         "urlPathPattern": "/mas/activity/X000001",
         "bodyPatterns": [
           {
-            "equalToJson": "{\"keywords\": \"No results\", \"dateFrom\": \"\", \"dateTo\": \"\", \"filters\": [], \"includeSystemGenerated\": true, \"typeCodes\": [] }"
+            "equalToJson": "{\"keywords\": \"No results\", \"dateFrom\": \"\", \"dateTo\": \"\", \"filters\": [], \"includeSystemGenerated\": true, \"filterBySparksContacts\": false, \"filterBySupervisionPackageContacts\": false, \"typeCodes\": [] }"
           }
         ]
       },
@@ -544,7 +544,7 @@
         "urlPathPattern": "/mas/activity/X000001",
         "bodyPatterns": [
           {
-            "equalToJson": "{\"keywords\": \"Phone call\", \"dateFrom\": \"\", \"dateTo\": \"\", \"filters\": [], \"includeSystemGenerated\": true, \"typeCodes\": []}"
+            "equalToJson": "{\"keywords\": \"Phone call\", \"dateFrom\": \"\", \"dateTo\": \"\", \"filters\": [], \"includeSystemGenerated\": true, \"filterBySparksContacts\": false, \"filterBySupervisionPackageContacts\": false, \"typeCodes\": []}"
           }
         ]
       },
@@ -608,7 +608,7 @@
         "urlPathPattern": "/mas/activity/X000001",
         "bodyPatterns": [
           {
-            "equalToJson": "{\"keywords\": \"Phone call\", \"dateFrom\": \"2025-01-20\", \"dateTo\": \"2025-01-27\", \"filters\": [\"noOutcome\", \"complied\", \"notComplied\"], \"includeSystemGenerated\": true, \"typeCodes\": []}"
+            "equalToJson": "{\"keywords\": \"Phone call\", \"dateFrom\": \"2025-01-20\", \"dateTo\": \"2025-01-27\", \"filters\": [\"noOutcome\", \"complied\", \"notComplied\"], \"includeSystemGenerated\": true, \"filterBySparksContacts\": false, \"filterBySupervisionPackageContacts\": false, \"typeCodes\": []}"
           }
         ]
       },
@@ -672,7 +672,7 @@
         "urlPathPattern": "/mas/activity/X000001",
         "bodyPatterns": [
           {
-            "equalToJson": "{\"keywords\": \"\", \"dateFrom\": \"2025-01-20\", \"dateTo\": \"2025-01-27\", \"filters\": [], \"includeSystemGenerated\": true, \"typeCodes\": []}"
+            "equalToJson": "{\"keywords\": \"\", \"dateFrom\": \"2025-01-20\", \"dateTo\": \"2025-01-27\", \"filters\": [], \"includeSystemGenerated\": true, \"filterBySparksContacts\": false, \"filterBySupervisionPackageContacts\": false, \"typeCodes\": []}"
           }
         ]
       },
@@ -736,7 +736,7 @@
         "urlPathPattern": "/mas/activity/X000001",
         "bodyPatterns": [
           {
-            "equalToJson": "{\"keywords\": \"\", \"dateFrom\": \"\", \"dateTo\": \"\", \"filters\": [\"noOutcome\", \"complied\", \"notComplied\"], \"includeSystemGenerated\": true, \"typeCodes\": []}"
+            "equalToJson": "{\"keywords\": \"\", \"dateFrom\": \"\", \"dateTo\": \"\", \"filters\": [\"noOutcome\", \"complied\", \"notComplied\"], \"includeSystemGenerated\": true, \"filterBySparksContacts\": false, \"filterBySupervisionPackageContacts\": false, \"typeCodes\": []}"
           }
         ]
       },
@@ -868,7 +868,7 @@
         "urlPathPattern": "/mas/activity/X000001",
         "bodyPatterns": [
           {
-            "equalToJson": "{\"keywords\": \"\", \"dateFrom\": \"\", \"dateTo\": \"\", \"filters\": [\"noOutcome\", \"complied\"], \"includeSystemGenerated\": true, \"typeCodes\": []}"
+            "equalToJson": "{\"keywords\": \"\", \"dateFrom\": \"\", \"dateTo\": \"\", \"filters\": [\"noOutcome\", \"complied\"], \"includeSystemGenerated\": true, \"filterBySparksContacts\": false, \"filterBySupervisionPackageContacts\": false, \"typeCodes\": []}"
           }
         ]
       },
@@ -1798,7 +1798,7 @@
         "urlPathPattern": "/mas/activity/X000001",
         "bodyPatterns": [
           {
-            "equalToJson": "{\"keywords\": \"\", \"dateFrom\": \"\", \"dateTo\": \"\", \"filters\": [], \"includeSystemGenerated\": false, \"typeCodes\": []}"
+            "equalToJson": "{\"keywords\": \"\", \"dateFrom\": \"\", \"dateTo\": \"\", \"filters\": [], \"includeSystemGenerated\": false, \"filterBySparksContacts\": false, \"filterBySupervisionPackageContacts\": false, \"typeCodes\": []}"
           }
         ]
       },

--- a/wiremock/mappings/X778160-activity-log.json
+++ b/wiremock/mappings/X778160-activity-log.json
@@ -486,7 +486,7 @@
         "urlPathPattern": "/mas/activity/X778160",
         "bodyPatterns": [
           {
-            "equalToJson": "{\"keywords\": \"No results\", \"dateFrom\": \"\", \"dateTo\": \"\", \"filters\": [], \"includeSystemGenerated\": true, \"typeCodes\": [] }"
+            "equalToJson": "{\"keywords\": \"No results\", \"dateFrom\": \"\", \"dateTo\": \"\", \"filters\": [], \"includeSystemGenerated\": true, \"filterBySparksContacts\": false, \"filterBySupervisionPackageContacts\": false, \"typeCodes\": [] }"
           }
         ]
       },
@@ -518,7 +518,7 @@
         "urlPathPattern": "/mas/activity/X778160",
         "bodyPatterns": [
           {
-            "equalToJson": "{\"keywords\": \"Phone call\", \"dateFrom\": \"\", \"dateTo\": \"\", \"filters\": [], \"includeSystemGenerated\": true, \"typeCodes\": []}"
+            "equalToJson": "{\"keywords\": \"Phone call\", \"dateFrom\": \"\", \"dateTo\": \"\", \"filters\": [], \"includeSystemGenerated\": true, \"filterBySparksContacts\": false, \"filterBySupervisionPackageContacts\": false, \"typeCodes\": []}"
           }
         ]
       },
@@ -582,7 +582,7 @@
         "urlPathPattern": "/mas/activity/X778160",
         "bodyPatterns": [
           {
-            "equalToJson": "{\"keywords\": \"Phone call\", \"dateFrom\": \"2025-01-20\", \"dateTo\": \"2025-01-27\", \"filters\": [\"noOutcome\", \"complied\", \"notComplied\"], \"includeSystemGenerated\": true, \"typeCodes\": []}"
+            "equalToJson": "{\"keywords\": \"Phone call\", \"dateFrom\": \"2025-01-20\", \"dateTo\": \"2025-01-27\", \"filters\": [\"noOutcome\", \"complied\", \"notComplied\"], \"includeSystemGenerated\": true, \"filterBySparksContacts\": false, \"filterBySupervisionPackageContacts\": false, \"typeCodes\": []}"
           }
         ]
       },
@@ -646,7 +646,7 @@
         "urlPathPattern": "/mas/activity/X778160",
         "bodyPatterns": [
           {
-            "equalToJson": "{\"keywords\": \"\", \"dateFrom\": \"2025-01-20\", \"dateTo\": \"2025-01-27\", \"filters\": [], \"includeSystemGenerated\": true, \"typeCodes\": []}"
+            "equalToJson": "{\"keywords\": \"\", \"dateFrom\": \"2025-01-20\", \"dateTo\": \"2025-01-27\", \"filters\": [], \"includeSystemGenerated\": true, \"filterBySparksContacts\": false, \"filterBySupervisionPackageContacts\": false, \"typeCodes\": []}"
           }
         ]
       },
@@ -710,7 +710,7 @@
         "urlPathPattern": "/mas/activity/X778160",
         "bodyPatterns": [
           {
-            "equalToJson": "{\"keywords\": \"\", \"dateFrom\": \"\", \"dateTo\": \"\", \"filters\": [\"noOutcome\", \"complied\", \"notComplied\"], \"includeSystemGenerated\": true, \"typeCodes\": []}"
+            "equalToJson": "{\"keywords\": \"\", \"dateFrom\": \"\", \"dateTo\": \"\", \"filters\": [\"noOutcome\", \"complied\", \"notComplied\"], \"includeSystemGenerated\": true, \"filterBySparksContacts\": false, \"filterBySupervisionPackageContacts\": false, \"typeCodes\": []}"
           }
         ]
       },
@@ -842,7 +842,7 @@
         "urlPathPattern": "/mas/activity/X778160",
         "bodyPatterns": [
           {
-            "equalToJson": "{\"keywords\": \"\", \"dateFrom\": \"\", \"dateTo\": \"\", \"filters\": [\"noOutcome\", \"complied\"], \"includeSystemGenerated\": true, \"typeCodes\": []}"
+            "equalToJson": "{\"keywords\": \"\", \"dateFrom\": \"\", \"dateTo\": \"\", \"filters\": [\"noOutcome\", \"complied\"], \"includeSystemGenerated\": true, \"filterBySparksContacts\": false, \"filterBySupervisionPackageContacts\": false, \"typeCodes\": []}"
           }
         ]
       },
@@ -1644,7 +1644,7 @@
         "urlPathPattern": "/mas/activity/X778160",
         "bodyPatterns": [
           {
-            "equalToJson": "{\"keywords\": \"\", \"dateFrom\": \"\", \"dateTo\": \"\", \"filters\": [], \"includeSystemGenerated\": false, \"typeCodes\": []}"
+            "equalToJson": "{\"keywords\": \"\", \"dateFrom\": \"\", \"dateTo\": \"\", \"filters\": [], \"includeSystemGenerated\": false, \"filterBySparksContacts\": false, \"filterBySupervisionPackageContacts\": false, \"typeCodes\": []}"
           }
         ]
       },


### PR DESCRIPTION
### MAN-3121 
 
 ## Summary
- Change how the SPARKS and Supervision-package activity-log filters are sent to the MAS API: nstead of injecting code strings (`"sparks"`, `"supervisionPackage"`) into the request body's `filters` array, they are now sent as dedicated top-level booleans `filterBySparksContacts` and `filterBySupervisionPackageContacts`.
