### PR TITLE
MAN-3235: Content update tier change prompt

### DIFF
--- a/integration_tests/e2e/tierChangePrompt.cy.ts
+++ b/integration_tests/e2e/tierChangePrompt.cy.ts
@@ -35,7 +35,7 @@ context('Tier change prompt', () => {
     cy.task('resetMocks')
   })
 
-  it('AC: shows a tier change prompt when the tier changed within the last 7 days (previous + new tier + recalculated wording)', () => {
+  it('AC: shows a tier change prompt when the tier changed within the last 7 days (previous + new tier)', () => {
     enablePrompt()
     noOutcomes()
     stubHistory([entry('A1', daysAgo(0)), entry('A2', daysAgo(60))])
@@ -44,7 +44,6 @@ context('Tier change prompt', () => {
     page.notificationHeading().should('contain.text', 'Information that needs your attention')
     page.tierChangePromptLink().should('exist').and('contain.text', 'tier has changed from A2 to A1')
     page.notificationBannerContent().should('contain.text', 'Caroline')
-    page.notificationBannerContent().should('contain.text', 'and their supervision package has been recalculated')
     // Only one item -> rendered as a single line, not a bulleted list item
     page.tierChangePromptItem().should('not.exist')
   })

--- a/server/views/pages/overview.njk
+++ b/server/views/pages/overview.njk
@@ -151,7 +151,7 @@
     {% if hasTierChangeItem %}{% set itemCount = itemCount + 1 %}{% endif %}
 
     {% set outcomesItem %}<a href="/case/{{ crn }}/record-an-outcome/outcome">You need to record an outcome for {{ appointmentsWithoutAnOutcomeCount }} {{ 'appointment' if appointmentsWithoutAnOutcomeCount == 1 else 'appointments' }}</a>.{% endset %}
-    {% set tierChangeItem %}<a href="{{ tierChangePrompt.historyHref }}" data-qa="tierChangePromptLink">{{ personForename }}’s tier has changed from {{ tierChangePrompt.oldTier }} to {{ tierChangePrompt.newTier }}</a> and their supervision package has been recalculated.{% endset %}
+    {% set tierChangeItem %}<a href="{{ tierChangePrompt.historyHref }}" data-qa="tierChangePromptLink">{{ personForename }}’s tier has changed from {{ tierChangePrompt.oldTier }} to {{ tierChangePrompt.newTier }}</a>.{% endset %}
 
     {% if itemCount > 0 %}
       {% set html %}


### PR DESCRIPTION
 ### MAN-3235
 
 ### Summary
- Simplifies the tier change notification banner on the case overview page by removing the trailing "and their supervision package has been recalculated" wording

<img width="1275" height="242" alt="image" src="https://github.com/user-attachments/assets/a66995f5-6f1b-47e0-8d3e-0b290822aee1" />
